### PR TITLE
using plural cluster in api group

### DIFF
--- a/clusters/install.go
+++ b/clusters/install.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	GroupName = "cluster.open-cluster-management.io"
+	GroupName = "clusters.open-cluster-management.io"
 )
 
 var (

--- a/clusters/v1/register.go
+++ b/clusters/v1/register.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	GroupName     = "cluster.open-cluster-management.io"
+	GroupName     = "clusters.open-cluster-management.io"
 	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1"}
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// Install is a function which adds this version to a scheme


### PR DESCRIPTION
Our generated client cannot list the `spokecluster` due to

```
Failed to list *v1.SpokeCluster: the server could not find the requested resource (get spokeclusters.cluster.open-cluster-management.io)
```

this because we register the api with a singular cluster in api group (spokeclusters.**cluster**.open-cluster-management.io), I think we should use the plural form

