### PR TITLE
add subresources section to crd

### DIFF
--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_spokeclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_spokeclusters.crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: spokeclusters
     singular: spokecluster
   scope: "Cluster"
+  subresources:
+    status: {}
   preserveUnknownFields: false
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
We need add `subresources` section to crd, or else, the `UpdateStatus` method cannot work, due to there is no `sub-resource` path