### PR TITLE
update development doc and regenerate clustermanagementaddons crd

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH

--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -5,10 +5,10 @@ metadata:
   name: clustermanagementaddons.addon.open-cluster-management.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.displayName
+  - JSONPath: .spec.addOnMeta.displayName
     name: DISPLAY NAME
     type: string
-  - JSONPath: .spec.addOnConfigCRD
+  - JSONPath: .spec.addOnConfiguration.crdName
     name: CRD NAME
     type: string
   group: addon.open-cluster-management.io


### PR DESCRIPTION
Updates:
- added steps for generating CRDs & generating deepcopy.zz
- updated docker image to use `fedora:32` to support golang 1.14.4+
- updated clustermanagementaddon's printcolumn by regenerating