### PR TITLE
add namespace to managedclusteraddon relatedobject

### DIFF
--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -236,6 +236,9 @@ spec:
                     name:
                       description: name of the referent.
                       type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
                     resource:
                       description: resource of the referent.
                       type: string

--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -133,6 +133,9 @@ type ObjectReference struct {
 	// +kubebuilder:validation:Required
 	// +required
 	Resource string `json:"resource"`
+	// namespace of the referent.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 	// name of the referent.
 	// +kubebuilder:validation:Required
 	// +required

--- a/addon/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/addon/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -110,10 +110,11 @@ func (ManagedClusterAddOnStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ObjectReference = map[string]string{
-	"":         "ObjectReference contains enough information to let you inspect or modify the referred object.",
-	"group":    "group of the referent.",
-	"resource": "resource of the referent.",
-	"name":     "name of the referent.",
+	"":          "ObjectReference contains enough information to let you inspect or modify the referred object.",
+	"group":     "group of the referent.",
+	"resource":  "resource of the referent.",
+	"namespace": "namespace of the referent.",
+	"name":      "name of the referent.",
 }
 
 func (ObjectReference) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

Added namespace in relatedObject to allow must-gather work on namespace scoped resources