### PR TITLE
Bugfix: Adding `omitempty` jsontag for ManifestWork.status.conditions

### DIFF
--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -117,7 +117,7 @@ type ManifestWorkStatus struct {
 	// 3. Available represents workload in ManifestWork exists on the managed cluster.
 	// 4. Degraded represents the current state of workload does not match the desired
 	// state for a certain period.
-	Conditions []metav1.Condition `json:"conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ResourceStatus represents the status of each resource in manifestwork deployed on a
 	// managed cluster. The Klusterlet agent on managed cluster syncs the condition from the managed cluster to the hub.


### PR DESCRIPTION
>$ kubectl apply --server-side -f manifestwork-example.yaml
....
....
I0506 15:03:19.363009   25916 request.go:1097] Request Body: {"apiVersion":"work.open-cluster-management.io/v1","kind":"ManifestWork","metadata":{"creationTimestamp":"2021-04-30T12:18:44Z","labels":{"foo":"bar"},"name":"demo-test","namespace":"zuoxiu-local"},"status":{"conditions":[]}} 
....
....
I0506 15:03:19.386561   25916 request.go:1097] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Apply failed with 1 conflict: conflict with \"work\" using work.open-cluster-management.io/v1: .status.conditions","reason":"Conflict","details":{"causes":[{"reason":"FieldManagerConflict","message":"conflict with \"work\" using work.open-cluster-management.io/v1","field":".status.conditions"}]},"code":409}
F0506 15:03:19.387107   25916 helpers.go:115] error: Apply failed with 1 conflict: conflict with "work" using work.open-cluster-management.io/v1: .status.conditions
Please review the fields above--they currently have other managers. Here...


b/c the status.conditions field doesnt have the omitempty tag, the server-side applying for manifestwork resources will be constantly failing due to apply conflict. as we can tell from the patch request body, a correct SSA body omitting status subresource should be `{"status":{}}`,  this pull will make SSA work on the manifestwork resources.



