### PR TITLE
update placement API

### DIFF
--- a/cluster/v1alpha1/0000_03_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/cluster/v1alpha1/0000_03_clusters.open-cluster-management.io_placements.crd.yaml
@@ -212,9 +212,7 @@ spec:
                           description: 'Name is the name of a prioritizer. Below are
                             the valid names: 1) Balance: balance the decisions among
                             the clusters. 2) Steady: ensure the existing decision
-                            is stabilized. 3) ResourceRatioCPU & ResourceRatioMemory:
-                            sort clusters based on the allocatable to capacity ratio.
-                            4) ResourceAllocatableCPU & ResourceAllocatableMemory:
+                            is stabilized. 3) ResourceAllocatableCPU & ResourceAllocatableMemory:
                             sort clusters based on the allocatable.'
                           type: string
                         weight:

--- a/cluster/v1alpha1/types.go
+++ b/cluster/v1alpha1/types.go
@@ -304,8 +304,7 @@ type PrioritizerConfig struct {
 	// Name is the name of a prioritizer. Below are the valid names:
 	// 1) Balance: balance the decisions among the clusters.
 	// 2) Steady: ensure the existing decision is stabilized.
-	// 3) ResourceRatioCPU & ResourceRatioMemory: sort clusters based on the allocatable to capacity ratio.
-	// 4) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.
+	// 3) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.
 	// +kubebuilder:validation:Required
 	// +required
 	Name string `json:"name"`

--- a/cluster/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/cluster/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -212,7 +212,7 @@ func (PlacementStatus) SwaggerDoc() map[string]string {
 
 var map_PrioritizerConfig = map[string]string{
 	"":       "PrioritizerConfig represents the configuration of prioritizer",
-	"name":   "Name is the name of a prioritizer. Below are the valid names: 1) Balance: balance the decisions among the clusters. 2) Steady: ensure the existing decision is stabilized. 3) ResourceRatioCPU & ResourceRatioMemory: sort clusters based on the allocatable to capacity ratio. 4) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.",
+	"name":   "Name is the name of a prioritizer. Below are the valid names: 1) Balance: balance the decisions among the clusters. 2) Steady: ensure the existing decision is stabilized. 3) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.",
 	"weight": "Weight defines the weight of prioritizer. The value must be ranged in [0,10]. Each prioritizer will calculate an integer score of a cluster in the range of [-100, 100]. The final score of a cluster will be sum(weight * prioritizer_score). A higher weight indicates that the prioritizer weights more in the cluster selection, while 0 weight indicate thats the prioritizer is disabled.",
 }
 


### PR DESCRIPTION
Ref: https://github.com/open-cluster-management/backlog/issues/15599
Refer to kubernetes node-allocatable definition https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable, it's a relatively stable value. 
As OCM allocatable is a sum of all the node's allocatable, so using the allocatable to capacity ratio doesn't help so much in scheduling. 
Remove it until we find a better solution. 

Signed-off-by: haoqing0110 <qhao@redhat.com>