### PR TITLE
upgrade CONTROLLER_GEN_VERSION to v0.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_BUILD_PACKAGES :=$(GO_PACKAGES)
 GO_BUILD_PACKAGES_EXPANDED :=$(GO_BUILD_PACKAGES)
 # LDFLAGS are not needed for dummy builds (saving time on calling git commands)
 GO_LD_FLAGS:=
-CONTROLLER_GEN_VERSION :=v0.2.5
+CONTROLLER_GEN_VERSION :=v0.6.0
 
 # $1 - target name
 # $2 - apis

--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -12,82 +12,58 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.addOnMeta.displayName
-      name: DISPLAY NAME
-      type: string
-    - jsonPath: .spec.addOnConfiguration.crdName
-      name: CRD NAME
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ClusterManagementAddOn represents the registration of an add-on
-          to the cluster manager. This resource allows the user to discover which
-          add-on is available for the cluster manager and also provides metadata information
-          about the add-on. This resource also provides a linkage to ManagedClusterAddOn,
-          the name of the ClusterManagementAddOn resource will be used for the namespace-scoped
-          ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped
-          resource.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec represents a desired configuration for the agent on
-              the cluster management add-on.
-            type: object
-            properties:
-              addOnConfiguration:
-                description: addOnConfiguration is a reference to configuration information
-                  for the add-on. In scenario where a multiple add-ons share the same
-                  add-on CRD, multiple ClusterManagementAddOn resources need to be
-                  created and reference the same AddOnConfiguration.
-                type: object
-                properties:
-                  crName:
-                    description: crName is the name of the CR used to configure instances
-                      of the managed add-on. This field should be configured if add-on
-                      CR have a consistent name across the all of the ManagedCluster
-                      instaces.
-                    type: string
-                  crdName:
-                    description: crdName is the name of the CRD used to configure
-                      instances of the managed add-on. This field should be configured
-                      if the add-on have a CRD that controls the configuration of
-                      the add-on.
-                    type: string
-              addOnMeta:
-                description: addOnMeta is a reference to the metadata information
-                  for the add-on.
-                type: object
-                properties:
-                  description:
-                    description: description represents the detailed description of
-                      the add-on.
-                    type: string
-                  displayName:
-                    description: displayName represents the name of add-on that will
-                      be displayed.
-                    type: string
-          status:
-            description: status represents the current status of cluster management
-              add-on.
-            type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.addOnMeta.displayName
+          name: DISPLAY NAME
+          type: string
+        - jsonPath: .spec.addOnConfiguration.crdName
+          name: CRD NAME
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterManagementAddOn represents the registration of an add-on to the cluster manager. This resource allows the user to discover which add-on is available for the cluster manager and also provides metadata information about the add-on. This resource also provides a linkage to ManagedClusterAddOn, the name of the ClusterManagementAddOn resource will be used for the namespace-scoped ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec represents a desired configuration for the agent on the cluster management add-on.
+              type: object
+              properties:
+                addOnConfiguration:
+                  description: addOnConfiguration is a reference to configuration information for the add-on. In scenario where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn resources need to be created and reference the same AddOnConfiguration.
+                  type: object
+                  properties:
+                    crName:
+                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                      type: string
+                    crdName:
+                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                      type: string
+                addOnMeta:
+                  description: addOnMeta is a reference to the metadata information for the add-on.
+                  type: object
+                  properties:
+                    description:
+                      description: description represents the detailed description of the add-on.
+                      type: string
+                    displayName:
+                      description: displayName represents the name of add-on that will be displayed.
+                      type: string
+            status:
+              description: status represents the current status of cluster management add-on.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -12,240 +12,165 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Available")].status
-      name: Available
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
-      name: Degraded
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
-      name: Progressing
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterAddOn is the Custom Resource object which holds
-          the current state of an add-on. This object is used by add-on operators
-          to convey their state. This resource should be created in the ManagedCluster
-          namespace.
-        type: object
-        required:
-        - spec
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec holds configuration that could apply to any operator.
-            type: object
-            properties:
-              installNamespace:
-                description: installNamespace is the namespace on the managed cluster
-                  to install the addon agent. If it is not set, open-cluster-management-agent-addon
-                  namespace is used to install the addon agent.
-                type: string
-                maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-          status:
-            description: status holds the information about the state of an operator.  It
-              is consistent with status information across the Kubernetes ecosystem.
-            type: object
-            properties:
-              addOnConfiguration:
-                description: addOnConfiguration is a reference to configuration information
-                  for the add-on. This resource is use to locate the configuration
-                  resource for the add-on.
-                type: object
-                properties:
-                  crName:
-                    description: crName is the name of the CR used to configure instances
-                      of the managed add-on. This field should be configured if add-on
-                      CR have a consistent name across the all of the ManagedCluster
-                      instaces.
-                    type: string
-                  crdName:
-                    description: crdName is the name of the CRD used to configure
-                      instances of the managed add-on. This field should be configured
-                      if the add-on have a CRD that controls the configuration of
-                      the add-on.
-                    type: string
-              addOnMeta:
-                description: addOnMeta is a reference to the metadata information
-                  for the add-on. This should be same as the addOnMeta for the corresponding
-                  ClusterManagementAddOn resource.
-                type: object
-                properties:
-                  description:
-                    description: description represents the detailed description of
-                      the add-on.
-                    type: string
-                  displayName:
-                    description: displayName represents the name of add-on that will
-                      be displayed.
-                    type: string
-              conditions:
-                description: conditions describe the state of the managed and monitored
-                  components for the operator.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              registrations:
-                description: registrations is the conifigurations for the addon agent
-                  to register to hub. It should be set by each addon controller on
-                  hub to define how the addon agent on managedcluster is registered.
-                  With the registration defined, The addon agent can access to kube
-                  apiserver with kube style API or other endpoints on hub cluster
-                  with client certificate authentication. A csr will be created per
-                  registration configuration. If more than one registrationConfig
-                  is defined, a csr will be created for each registration configuration.
-                  It is not allowed that multiple registrationConfigs have the same
-                  signer name. After the csr is approved on the hub cluster, the klusterlet
-                  agent will create a secret in the installNamespace for the registrationConfig.
-                  If the signerName is "kubernetes.io/kube-apiserver-client", the
-                  secret name will be "{addon name}-hub-kubeconfig" whose contents
-                  includes key/cert and kubeconfig. Otherwise, the secret name will
-                  be "{addon name}-{signer name}-client-cert" whose contents includes
-                  key/cert.
-                type: array
-                items:
-                  description: RegistrationConfig defines the configuration of the
-                    addon agent to register to hub. The Klusterlet agent will create
-                    a csr for the addon agent with the registrationConfig.
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Available")].status
+          name: Available
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+          name: Degraded
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+          name: Progressing
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterAddOn is the Custom Resource object which holds the current state of an add-on. This object is used by add-on operators to convey their state. This resource should be created in the ManagedCluster namespace.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds configuration that could apply to any operator.
+              type: object
+              properties:
+                installNamespace:
+                  description: installNamespace is the namespace on the managed cluster to install the addon agent. If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
+                  type: string
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            status:
+              description: status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.
+              type: object
+              properties:
+                addOnConfiguration:
+                  description: addOnConfiguration is a reference to configuration information for the add-on. This resource is use to locate the configuration resource for the add-on.
                   type: object
                   properties:
-                    signerName:
-                      description: signerName is the name of signer that addon agent
-                        will use to create csr.
+                    crName:
+                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
                       type: string
-                      maxLength: 571
-                      minLength: 5
-                    subject:
-                      description: "subject is the user subject of the addon agent
-                        to be registered to the hub. If it is not set, the addon agent
-                        will have the default subject \"subject\": { \t\"user\": \"system:open-cluster-management:addon:{addonName}:{clusterName}:{agentName}\",
-                        \t\"groups: [\"system:open-cluster-management:addon\", \"system:open-cluster-management:addon:{addonName}\",
-                        \"system:authenticated\"] }"
-                      type: object
-                      properties:
-                        groups:
-                          description: groups is the user group of the addon agent.
-                          type: array
-                          items:
+                    crdName:
+                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                      type: string
+                addOnMeta:
+                  description: addOnMeta is a reference to the metadata information for the add-on. This should be same as the addOnMeta for the corresponding ClusterManagementAddOn resource.
+                  type: object
+                  properties:
+                    description:
+                      description: description represents the detailed description of the add-on.
+                      type: string
+                    displayName:
+                      description: displayName represents the name of add-on that will be displayed.
+                      type: string
+                conditions:
+                  description: conditions describe the state of the managed and monitored components for the operator.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                registrations:
+                  description: registrations is the conifigurations for the addon agent to register to hub. It should be set by each addon controller on hub to define how the addon agent on managedcluster is registered. With the registration defined, The addon agent can access to kube apiserver with kube style API or other endpoints on hub cluster with client certificate authentication. A csr will be created per registration configuration. If more than one registrationConfig is defined, a csr will be created for each registration configuration. It is not allowed that multiple registrationConfigs have the same signer name. After the csr is approved on the hub cluster, the klusterlet agent will create a secret in the installNamespace for the registrationConfig. If the signerName is "kubernetes.io/kube-apiserver-client", the secret name will be "{addon name}-hub-kubeconfig" whose contents includes key/cert and kubeconfig. Otherwise, the secret name will be "{addon name}-{signer name}-client-cert" whose contents includes key/cert.
+                  type: array
+                  items:
+                    description: RegistrationConfig defines the configuration of the addon agent to register to hub. The Klusterlet agent will create a csr for the addon agent with the registrationConfig.
+                    type: object
+                    properties:
+                      signerName:
+                        description: signerName is the name of signer that addon agent will use to create csr.
+                        type: string
+                        maxLength: 571
+                        minLength: 5
+                      subject:
+                        description: "subject is the user subject of the addon agent to be registered to the hub. If it is not set, the addon agent will have the default subject \"subject\": { \t\"user\": \"system:open-cluster-management:addon:{addonName}:{clusterName}:{agentName}\", \t\"groups: [\"system:open-cluster-management:addon\", \"system:open-cluster-management:addon:{addonName}\", \"system:authenticated\"] }"
+                        type: object
+                        properties:
+                          groups:
+                            description: groups is the user group of the addon agent.
+                            type: array
+                            items:
+                              type: string
+                          organizationUnit:
+                            description: organizationUnit is the ou of the addon agent
+                            type: array
+                            items:
+                              type: string
+                          user:
+                            description: user is the user name of the addon agent.
                             type: string
-                        organizationUnit:
-                          description: organizationUnit is the ou of the addon agent
-                          type: array
-                          items:
-                            type: string
-                        user:
-                          description: user is the user name of the addon agent.
-                          type: string
-              relatedObjects:
-                description: 'relatedObjects is a list of objects that are "interesting"
-                  or related to this operator. Common uses are: 1. the detailed resource
-                  driving the operator 2. operator namespaces 3. operand namespaces
-                  4. related ClusterManagementAddon resource'
-                type: array
-                items:
-                  description: ObjectReference contains enough information to let
-                    you inspect or modify the referred object.
-                  type: object
-                  required:
-                  - group
-                  - name
-                  - resource
-                  properties:
-                    group:
-                      description: group of the referent.
-                      type: string
-                    name:
-                      description: name of the referent.
-                      type: string
-                    namespace:
-                      description: namespace of the referent.
-                      type: string
-                    resource:
-                      description: resource of the referent.
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                relatedObjects:
+                  description: 'relatedObjects is a list of objects that are "interesting" or related to this operator. Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces 4. related ClusterManagementAddon resource'
+                  type: array
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    type: object
+                    required:
+                      - group
+                      - name
+                      - resource
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -9,233 +9,161 @@ spec:
     listKind: ManagedClusterList
     plural: managedclusters
     shortNames:
-    - mcl
-    - mcls
+      - mcl
+      - mcls
     singular: managedcluster
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.hubAcceptsClient
-      name: Hub Accepted
-      type: boolean
-    - jsonPath: .spec.managedClusterClientConfigs[*].url
-      name: Managed Cluster URLs
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
-      name: Joined
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
-      name: Available
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: "ManagedCluster represents the desired state and current status
-          of managed cluster. ManagedCluster is a cluster scoped resource. The name
-          is the cluster UID. \n The cluster join process follows a double opt-in
-          process: \n 1. Agent on managed cluster creates CSR on hub with cluster
-          UID and agent name. 2. Agent on managed cluster creates ManagedCluster on
-          hub. 3. Cluster admin on hub approves the CSR for UID and agent name of
-          the ManagedCluster. 4. Cluster admin sets spec.acceptClient of ManagedCluster
-          to true. 5. Cluster admin on managed cluster creates credential of kubeconfig
-          to hub. \n Once the hub creates the cluster namespace, the Klusterlet agent
-          on the ManagedCluster pushes the credential to the hub to use against the
-          kube-apiserver of the ManagedCluster."
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents a desired configuration for the agent on
-              the managed cluster.
-            type: object
-            properties:
-              hubAcceptsClient:
-                description: hubAcceptsClient represents that hub accepts the joining
-                  of Klusterlet agent on the managed cluster with the hub. The default
-                  value is false, and can only be set true when the user on hub has
-                  an RBAC rule to UPDATE on the virtual subresource of managedclusters/accept.
-                  When the value is set true, a namespace whose name is the same as
-                  the name of ManagedCluster is created on the hub. This namespace
-                  represents the managed cluster, also role/rolebinding is created
-                  on the namespace to grant the permision of access from the agent
-                  on the managed cluster. When the value is set to false, the namespace
-                  representing the managed cluster is deleted.
-                type: boolean
-              leaseDurationSeconds:
-                description: LeaseDurationSeconds is used to coordinate the lease
-                  update time of Klusterlet agents on the managed cluster. If its
-                  value is zero, the Klusterlet agent will update its lease every
-                  60 seconds by default
-                type: integer
-                format: int32
-              managedClusterClientConfigs:
-                description: ManagedClusterClientConfigs represents a list of the
-                  apiserver address of the managed cluster. If it is empty, the managed
-                  cluster has no accessible address for the hub to connect with it.
-                type: array
-                items:
-                  description: ClientConfig represents the apiserver address of the
-                    managed cluster. TODO include credential to connect to managed
-                    cluster kube-apiserver
+    - additionalPrinterColumns:
+        - jsonPath: .spec.hubAcceptsClient
+          name: Hub Accepted
+          type: boolean
+        - jsonPath: .spec.managedClusterClientConfigs[*].url
+          name: Managed Cluster URLs
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
+          name: Joined
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
+          name: Available
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ManagedCluster represents the desired state and current status of managed cluster. ManagedCluster is a cluster scoped resource. The name is the cluster UID. \n The cluster join process follows a double opt-in process: \n 1. Agent on managed cluster creates CSR on hub with cluster UID and agent name. 2. Agent on managed cluster creates ManagedCluster on hub. 3. Cluster admin on hub approves the CSR for UID and agent name of the ManagedCluster. 4. Cluster admin sets spec.acceptClient of ManagedCluster to true. 5. Cluster admin on managed cluster creates credential of kubeconfig to hub. \n Once the hub creates the cluster namespace, the Klusterlet agent on the ManagedCluster pushes the credential to the hub to use against the kube-apiserver of the ManagedCluster."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired configuration for the agent on the managed cluster.
+              type: object
+              properties:
+                hubAcceptsClient:
+                  description: hubAcceptsClient represents that hub accepts the joining of Klusterlet agent on the managed cluster with the hub. The default value is false, and can only be set true when the user on hub has an RBAC rule to UPDATE on the virtual subresource of managedclusters/accept. When the value is set true, a namespace whose name is the same as the name of ManagedCluster is created on the hub. This namespace represents the managed cluster, also role/rolebinding is created on the namespace to grant the permision of access from the agent on the managed cluster. When the value is set to false, the namespace representing the managed cluster is deleted.
+                  type: boolean
+                leaseDurationSeconds:
+                  description: LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster. If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
+                  type: integer
+                  format: int32
+                managedClusterClientConfigs:
+                  description: ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster. If it is empty, the managed cluster has no accessible address for the hub to connect with it.
+                  type: array
+                  items:
+                    description: ClientConfig represents the apiserver address of the managed cluster. TODO include credential to connect to managed cluster kube-apiserver
+                    type: object
+                    properties:
+                      caBundle:
+                        description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                        type: string
+                        format: byte
+                      url:
+                        description: URL is the URL of apiserver endpoint of the managed cluster.
+                        type: string
+            status:
+              description: Status represents the current status of joined managed cluster
+              type: object
+              properties:
+                allocatable:
+                  description: Allocatable represents the total allocatable resources on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                capacity:
+                  description: Capacity represents the total resource capacity from all nodeStatuses on the managed cluster.
+                  type: object
+                  additionalProperties:
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    x-kubernetes-int-or-string: true
+                clusterClaims:
+                  description: ClusterClaims represents cluster information that a managed cluster claims, for example a unique cluster identifier (id.k8s.io) and kubernetes version (kubeversion.open-cluster-management.io). They are written from the managed cluster. The set of claims is not uniform across a fleet, some claims can be vendor or version specific and may not be included from all managed clusters.
+                  type: array
+                  items:
+                    description: ManagedClusterClaim represents a ClusterClaim collected from a managed cluster.
+                    type: object
+                    properties:
+                      name:
+                        description: Name is the name of a ClusterClaim resource on managed cluster. It's a well known or customized name to identify the claim.
+                        type: string
+                        maxLength: 253
+                        minLength: 1
+                      value:
+                        description: Value is a claim-dependent string
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                conditions:
+                  description: Conditions contains the different condition statuses for this managed cluster.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                version:
+                  description: Version represents the kubernetes version of the managed cluster.
                   type: object
                   properties:
-                    caBundle:
-                      description: CABundle is the ca bundle to connect to apiserver
-                        of the managed cluster. System certs are used if it is not
-                        set.
+                    kubernetes:
+                      description: Kubernetes is the kubernetes version of managed cluster.
                       type: string
-                      format: byte
-                    url:
-                      description: URL is the URL of apiserver endpoint of the managed
-                        cluster.
-                      type: string
-          status:
-            description: Status represents the current status of joined managed cluster
-            type: object
-            properties:
-              allocatable:
-                description: Allocatable represents the total allocatable resources
-                  on the managed cluster.
-                type: object
-                additionalProperties:
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
-              capacity:
-                description: Capacity represents the total resource capacity from
-                  all nodeStatuses on the managed cluster.
-                type: object
-                additionalProperties:
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
-              clusterClaims:
-                description: ClusterClaims represents cluster information that a managed
-                  cluster claims, for example a unique cluster identifier (id.k8s.io)
-                  and kubernetes version (kubeversion.open-cluster-management.io).
-                  They are written from the managed cluster. The set of claims is
-                  not uniform across a fleet, some claims can be vendor or version
-                  specific and may not be included from all managed clusters.
-                type: array
-                items:
-                  description: ManagedClusterClaim represents a ClusterClaim collected
-                    from a managed cluster.
-                  type: object
-                  properties:
-                    name:
-                      description: Name is the name of a ClusterClaim resource on
-                        managed cluster. It's a well known or customized name to identify
-                        the claim.
-                      type: string
-                      maxLength: 253
-                      minLength: 1
-                    value:
-                      description: Value is a claim-dependent string
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this managed cluster.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              version:
-                description: Version represents the kubernetes version of the managed
-                  cluster.
-                type: object
-                properties:
-                  kubernetes:
-                    description: Kubernetes is the kubernetes version of managed cluster.
-                    type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/cluster/v1alpha1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -9,123 +9,81 @@ spec:
     listKind: ManagedClusterSetList
     plural: managedclustersets
     shortNames:
-    - mclset
-    - mclsets
+      - mclset
+      - mclsets
     singular: managedclusterset
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "ManagedClusterSet defines a group of ManagedClusters that user's
-          workload can run on. A workload can be defined to deployed on a ManagedClusterSet,
-          which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet
-          \  2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet
-          \  3. The service exposed by the workload can be shared in any ManagedCluster
-          in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian
-          ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset`
-          on the ManagedCluster to refers to the ManagedClusterSet. User is not allow
-          to add/remove this label on a ManagedCluster unless they have a RBAC rule
-          to CREATE on a virtual subresource of managedclustersets/join. In order
-          to update this label, user must have the permission on both the old and
-          new ManagedClusterSet."
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of the ManagedClusterSet
-            type: object
-          status:
-            description: Status represents the current status of the ManagedClusterSet
-            type: object
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this ManagedClusterSet.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "ManagedClusterSet defines a group of ManagedClusters that user's workload can run on. A workload can be defined to deployed on a ManagedClusterSet, which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet   2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet   3. The service exposed by the workload can be shared in any ManagedCluster in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset` on the ManagedCluster to refers to the ManagedClusterSet. User is not allow to add/remove this label on a ManagedCluster unless they have a RBAC rule to CREATE on a virtual subresource of managedclustersets/join. In order to update this label, user must have the permission on both the old and new ManagedClusterSet."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ManagedClusterSet
+              type: object
+            status:
+              description: Status represents the current status of the ManagedClusterSet
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSet.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/cluster/v1alpha1/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -9,49 +9,36 @@ spec:
     listKind: ManagedClusterSetBindingList
     plural: managedclustersetbindings
     shortNames:
-    - mclsetbinding
-    - mclsetbindings
+      - mclsetbinding
+      - mclsetbindings
     singular: managedclustersetbinding
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
-          certain namespace. User is able to create a ManagedClusterSetBinding in
-          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
-          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
-          created in the same namespace can only be distributed to ManagedClusters
-          in ManagedClusterSets bound in this namespace by higher level controllers.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of ManagedClusterSetBinding.
-            type: object
-            properties:
-              clusterSet:
-                description: ClusterSet is the name of the ManagedClusterSet to bind.
-                  It must match the instance name of the ManagedClusterSetBinding
-                  and cannot change once created. User is allowed to set this field
-                  if they have an RBAC rule to CREATE on the virtual subresource of
-                  managedclustersets/bind.
-                type: string
-                minLength: 1
-    served: true
-    storage: true
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterSetBinding projects a ManagedClusterSet into a certain namespace. User is able to create a ManagedClusterSetBinding in a namespace and bind it to a ManagedClusterSet if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind. Workloads created in the same namespace can only be distributed to ManagedClusters in ManagedClusterSets bound in this namespace by higher level controllers.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of ManagedClusterSetBinding.
+              type: object
+              properties:
+                clusterSet:
+                  description: ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding and cannot change once created. User is allowed to set this field if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind.
+                  type: string
+                  minLength: 1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
+++ b/cluster/v1alpha1/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
@@ -12,40 +12,31 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ClusterClaim represents cluster information that a managed cluster
-          claims ClusterClaims with well known names include,   1. id.k8s.io, it contains
-          a unique identifier for the cluster.   2. clusterset.k8s.io, it contains
-          an identifier that relates the cluster      to the ClusterSet in which it
-          belongs. ClusterClaims created on a managed cluster will be collected and
-          saved into the status of the corresponding ManagedCluster on hub.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of the ClusterClaim.
-            type: object
-            properties:
-              value:
-                description: Value is a claim-dependent string
-                type: string
-                maxLength: 1024
-                minLength: 1
-    served: true
-    storage: true
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterClaim represents cluster information that a managed cluster claims ClusterClaims with well known names include,   1. id.k8s.io, it contains a unique identifier for the cluster.   2. clusterset.k8s.io, it contains an identifier that relates the cluster      to the ClusterSet in which it belongs. ClusterClaims created on a managed cluster will be collected and saved into the status of the corresponding ManagedCluster on hub.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ClusterClaim.
+              type: object
+              properties:
+                value:
+                  description: Value is a claim-dependent string
+                  type: string
+                  maxLength: 1024
+                  minLength: 1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0000_03_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/cluster/v1alpha1/0000_03_clusters.open-cluster-management.io_placements.crd.yaml
@@ -12,319 +12,193 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="PlacementSatisfied")].status
-      name: Succeeded
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="PlacementSatisfied")].reason
-      name: Reason
-      type: string
-    - jsonPath: .status.numberOfSelectedClusters
-      name: SelectedClusters
-      type: integer
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "Placement defines a rule to select a set of ManagedClusters
-          from the ManagedClusterSets bound to the placement namespace. \n Here is
-          how the placement policy combines with other selection methods to determine
-          a matching list of ManagedClusters: 1) Kubernetes clusters are registered
-          with hub as cluster-scoped ManagedClusters; 2) ManagedClusters are organized
-          into cluster-scoped ManagedClusterSets; 3) ManagedClusterSets are bound
-          to workload namespaces; 4) Namespace-scoped Placements specify a slice of
-          ManagedClusterSets which select a working set    of potential ManagedClusters;
-          5) Then Placements subselect from that working set using label/claim selection.
-          \n No ManagedCluster will be selected if no ManagedClusterSet is bound to
-          the placement namespace. User is able to bind a ManagedClusterSet to a namespace
-          by creating a ManagedClusterSetBinding in that namespace if they have a
-          RBAC rule to CREATE on the virtual subresource of `managedclustersets/bind`.
-          \n A slice of PlacementDecisions with label cluster.open-cluster-management.io/placement={placement
-          name} will be created to represent the ManagedClusters selected by this
-          placement. \n If a ManagedCluster is selected and added into the PlacementDecisions,
-          other components may apply workload on it; once it is removed from the PlacementDecisions,
-          the workload applied on this ManagedCluster should be evicted accordingly."
-        type: object
-        required:
-        - spec
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of Placement.
-            type: object
-            properties:
-              clusterSets:
-                description: ClusterSets represent the ManagedClusterSets from which
-                  the ManagedClusters are selected. If the slice is empty, ManagedClusters
-                  will be selected from the ManagedClusterSets bound to the placement
-                  namespace, otherwise ManagedClusters will be selected from the intersection
-                  of this slice and the ManagedClusterSets bound to the placement
-                  namespace.
-                type: array
-                items:
-                  type: string
-              numberOfClusters:
-                description: NumberOfClusters represents the desired number of ManagedClusters
-                  to be selected which meet the placement requirements. 1) If not
-                  specified, all ManagedClusters which meet the placement requirements
-                  (including ClusterSets,    and Predicates) will be selected; 2)
-                  Otherwise if the nubmer of ManagedClusters meet the placement requirements
-                  is larger than    NumberOfClusters, a random subset with desired
-                  number of ManagedClusters will be selected; 3) If the nubmer of
-                  ManagedClusters meet the placement requirements is equal to NumberOfClusters,    all
-                  of them will be selected; 4) If the nubmer of ManagedClusters meet
-                  the placement requirements is less than NumberOfClusters,    all
-                  of them will be selected, and the status of condition `PlacementConditionSatisfied`
-                  will be    set to false;
-                type: integer
-                format: int32
-              predicates:
-                description: Predicates represent a slice of predicates to select
-                  ManagedClusters. The predicates are ORed.
-                type: array
-                items:
-                  description: ClusterPredicate represents a predicate to select ManagedClusters.
-                  type: object
-                  properties:
-                    requiredClusterSelector:
-                      description: RequiredClusterSelector represents a selector of
-                        ManagedClusters by label and claim. If specified, 1) Any ManagedCluster,
-                        which does not match the selector, should not be selected
-                        by this ClusterPredicate; 2) If a selected ManagedCluster
-                        (of this ClusterPredicate) ceases to match the selector (e.g.
-                        due to    an update) of any ClusterPredicate, it will be eventually
-                        removed from the placement decisions; 3) If a ManagedCluster
-                        (not selected previously) starts to match the selector, it
-                        will either    be selected or at least has a chance to be
-                        selected (when NumberOfClusters is specified);
-                      type: object
-                      properties:
-                        claimSelector:
-                          description: ClaimSelector represents a selector of ManagedClusters
-                            by clusterClaims in status
-                          type: object
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of cluster claim
-                                selector requirements. The requirements are ANDed.
-                              type: array
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    type: array
-                                    items:
-                                      type: string
-                        labelSelector:
-                          description: LabelSelector represents a selector of ManagedClusters
-                            by label
-                          type: object
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              type: array
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                type: object
-                                required:
-                                - key
-                                - operator
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    type: array
-                                    items:
-                                      type: string
-                            matchLabels:
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                              additionalProperties:
-                                type: string
-              prioritizerPolicy:
-                description: PrioritizerPolicy defines the policy of the prioritizers.
-                  If this field is unset, then default prioritizer mode and configurations
-                  are used. Referring to PrioritizerPolicy to see more description
-                  about Mode and Configurations.
-                type: object
-                properties:
-                  configurations:
-                    type: array
-                    items:
-                      description: PrioritizerConfig represents the configuration
-                        of prioritizer
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        name:
-                          description: 'Name is the name of a prioritizer. Below are
-                            the valid names: 1) Balance: balance the decisions among
-                            the clusters. 2) Steady: ensure the existing decision
-                            is stabilized. 3) ResourceAllocatableCPU & ResourceAllocatableMemory:
-                            sort clusters based on the allocatable.'
-                          type: string
-                        weight:
-                          description: Weight defines the weight of prioritizer. The
-                            value must be ranged in [0,10]. Each prioritizer will
-                            calculate an integer score of a cluster in the range of
-                            [-100, 100]. The final score of a cluster will be sum(weight
-                            * prioritizer_score). A higher weight indicates that the
-                            prioritizer weights more in the cluster selection, while
-                            0 weight indicate thats the prioritizer is disabled.
-                          type: integer
-                          format: int32
-                          default: 1
-                          maximum: 10
-                          minimum: 0
-                  mode:
-                    description: Mode is either Exact, Additive, "" where "" is Additive
-                      by default. In Additive mode, any prioritizer not explicitly
-                      enumerated is enabled in its default Configurations, in which
-                      Steady and Balance prioritizers have the weight of 1 while other
-                      prioritizers have the weight of 0. Additive doesn't require
-                      configuring all prioritizers. The default Configurations may
-                      change in the future, and additional prioritization will happen.
-                      In Exact mode, any prioritizer not explicitly enumerated is
-                      weighted as zero. Exact requires knowing the full set of prioritizers
-                      you want, but avoids behavior changes between releases.
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="PlacementSatisfied")].status
+          name: Succeeded
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="PlacementSatisfied")].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.numberOfSelectedClusters
+          name: SelectedClusters
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "Placement defines a rule to select a set of ManagedClusters from the ManagedClusterSets bound to the placement namespace. \n Here is how the placement policy combines with other selection methods to determine a matching list of ManagedClusters: 1) Kubernetes clusters are registered with hub as cluster-scoped ManagedClusters; 2) ManagedClusters are organized into cluster-scoped ManagedClusterSets; 3) ManagedClusterSets are bound to workload namespaces; 4) Namespace-scoped Placements specify a slice of ManagedClusterSets which select a working set    of potential ManagedClusters; 5) Then Placements subselect from that working set using label/claim selection. \n No ManagedCluster will be selected if no ManagedClusterSet is bound to the placement namespace. User is able to bind a ManagedClusterSet to a namespace by creating a ManagedClusterSetBinding in that namespace if they have a RBAC rule to CREATE on the virtual subresource of `managedclustersets/bind`. \n A slice of PlacementDecisions with label cluster.open-cluster-management.io/placement={placement name} will be created to represent the ManagedClusters selected by this placement. \n If a ManagedCluster is selected and added into the PlacementDecisions, other components may apply workload on it; once it is removed from the PlacementDecisions, the workload applied on this ManagedCluster should be evicted accordingly."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of Placement.
+              type: object
+              properties:
+                clusterSets:
+                  description: ClusterSets represent the ManagedClusterSets from which the ManagedClusters are selected. If the slice is empty, ManagedClusters will be selected from the ManagedClusterSets bound to the placement namespace, otherwise ManagedClusters will be selected from the intersection of this slice and the ManagedClusterSets bound to the placement namespace.
+                  type: array
+                  items:
                     type: string
-                    default: Additive
-          status:
-            description: Status represents the current status of the Placement
-            type: object
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this Placement.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                numberOfClusters:
+                  description: NumberOfClusters represents the desired number of ManagedClusters to be selected which meet the placement requirements. 1) If not specified, all ManagedClusters which meet the placement requirements (including ClusterSets,    and Predicates) will be selected; 2) Otherwise if the nubmer of ManagedClusters meet the placement requirements is larger than    NumberOfClusters, a random subset with desired number of ManagedClusters will be selected; 3) If the nubmer of ManagedClusters meet the placement requirements is equal to NumberOfClusters,    all of them will be selected; 4) If the nubmer of ManagedClusters meet the placement requirements is less than NumberOfClusters,    all of them will be selected, and the status of condition `PlacementConditionSatisfied` will be    set to false;
+                  type: integer
+                  format: int32
+                predicates:
+                  description: Predicates represent a slice of predicates to select ManagedClusters. The predicates are ORed.
+                  type: array
+                  items:
+                    description: ClusterPredicate represents a predicate to select ManagedClusters.
+                    type: object
+                    properties:
+                      requiredClusterSelector:
+                        description: RequiredClusterSelector represents a selector of ManagedClusters by label and claim. If specified, 1) Any ManagedCluster, which does not match the selector, should not be selected by this ClusterPredicate; 2) If a selected ManagedCluster (of this ClusterPredicate) ceases to match the selector (e.g. due to    an update) of any ClusterPredicate, it will be eventually removed from the placement decisions; 3) If a ManagedCluster (not selected previously) starts to match the selector, it will either    be selected or at least has a chance to be selected (when NumberOfClusters is specified);
+                        type: object
+                        properties:
+                          claimSelector:
+                            description: ClaimSelector represents a selector of ManagedClusters by clusterClaims in status
+                            type: object
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of cluster claim selector requirements. The requirements are ANDed.
+                                type: array
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  type: object
+                                  required:
+                                    - key
+                                    - operator
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      type: array
+                                      items:
+                                        type: string
+                          labelSelector:
+                            description: LabelSelector represents a selector of ManagedClusters by label
+                            type: object
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                type: array
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  type: object
+                                  required:
+                                    - key
+                                    - operator
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                prioritizerPolicy:
+                  description: PrioritizerPolicy defines the policy of the prioritizers. If this field is unset, then default prioritizer mode and configurations are used. Referring to PrioritizerPolicy to see more description about Mode and Configurations.
                   type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                    configurations:
+                      type: array
+                      items:
+                        description: PrioritizerConfig represents the configuration of prioritizer
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: 'Name is the name of a prioritizer. Below are the valid names: 1) Balance: balance the decisions among the clusters. 2) Steady: ensure the existing decision is stabilized. 3) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.'
+                            type: string
+                          weight:
+                            description: Weight defines the weight of prioritizer. The value must be ranged in [0,10]. Each prioritizer will calculate an integer score of a cluster in the range of [-100, 100]. The final score of a cluster will be sum(weight * prioritizer_score). A higher weight indicates that the prioritizer weights more in the cluster selection, while 0 weight indicate thats the prioritizer is disabled.
+                            type: integer
+                            format: int32
+                            default: 1
+                            maximum: 10
+                            minimum: 0
+                    mode:
+                      description: Mode is either Exact, Additive, "" where "" is Additive by default. In Additive mode, any prioritizer not explicitly enumerated is enabled in its default Configurations, in which Steady and Balance prioritizers have the weight of 1 while other prioritizers have the weight of 0. Additive doesn't require configuring all prioritizers. The default Configurations may change in the future, and additional prioritization will happen. In Exact mode, any prioritizer not explicitly enumerated is weighted as zero. Exact requires knowing the full set of prioritizers you want, but avoids behavior changes between releases.
                       type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              numberOfSelectedClusters:
-                description: NumberOfSelectedClusters represents the number of selected
-                  ManagedClusters
-                type: integer
-                format: int32
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                      default: Additive
+            status:
+              description: Status represents the current status of the Placement
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this Placement.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                numberOfSelectedClusters:
+                  description: NumberOfSelectedClusters represents the number of selected ManagedClusters
+                  type: integer
+                  format: int32
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0000_04_clusters.open-cluster-management.io_placementdecisions.crd.yaml
+++ b/cluster/v1alpha1/0000_04_clusters.open-cluster-management.io_placementdecisions.crd.yaml
@@ -12,62 +12,46 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "PlacementDecision indicates a decision from a placement PlacementDecision
-          should has a label cluster.open-cluster-management.io/placement={placement
-          name} to reference a certain placement. \n If a placement has spec.numberOfClusters
-          specified, the total number of decisions contained in status.decisions of
-          PlacementDecisions should always be NumberOfClusters; otherwise, the total
-          number of decisions should be the number of ManagedClusters which match
-          the placement requirements. \n Some of the decisions might be empty when
-          there are no enough ManagedClusters meet the placement requirements."
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          status:
-            description: Status represents the current status of the PlacementDecision
-            type: object
-            required:
-            - decisions
-            properties:
-              decisions:
-                description: Decisions is a slice of decisions according to a placement
-                  The number of decisions should not be larger than 100
-                type: array
-                items:
-                  description: ClusterDecision represents a decision from a placement
-                    An empty ClusterDecision indicates it is not scheduled yet.
-                  type: object
-                  required:
-                  - clusterName
-                  - reason
-                  properties:
-                    clusterName:
-                      description: ClusterName is the name of the ManagedCluster.
-                        If it is not empty, its value should be unique cross all placement
-                        decisions for the Placement.
-                      type: string
-                    reason:
-                      description: Reason represents the reason why the ManagedCluster
-                        is selected.
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "PlacementDecision indicates a decision from a placement PlacementDecision should has a label cluster.open-cluster-management.io/placement={placement name} to reference a certain placement. \n If a placement has spec.numberOfClusters specified, the total number of decisions contained in status.decisions of PlacementDecisions should always be NumberOfClusters; otherwise, the total number of decisions should be the number of ManagedClusters which match the placement requirements. \n Some of the decisions might be empty when there are no enough ManagedClusters meet the placement requirements."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            status:
+              description: Status represents the current status of the PlacementDecision
+              type: object
+              required:
+                - decisions
+              properties:
+                decisions:
+                  description: Decisions is a slice of decisions according to a placement The number of decisions should not be larger than 100
+                  type: array
+                  items:
+                    description: ClusterDecision represents a decision from a placement An empty ClusterDecision indicates it is not scheduled yet.
+                    type: object
+                    required:
+                      - clusterName
+                      - reason
+                    properties:
+                      clusterName:
+                        description: ClusterName is the name of the ManagedCluster. If it is not empty, its value should be unique cross all placement decisions for the Placement.
+                        type: string
+                      reason:
+                        description: Reason represents the reason why the ManagedCluster is selected.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1alpha1/0001_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
+++ b/cluster/v1alpha1/0001_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
@@ -13,23 +13,14 @@ spec:
   preserveUnknownFields: false
   validation:
     openAPIV3Schema:
-      description: ClusterClaim represents cluster information that a managed cluster
-        claims ClusterClaims with well known names include,   1. id.k8s.io, it contains
-        a unique identifier for the cluster.   2. clusterset.k8s.io, it contains an
-        identifier that relates the cluster      to the ClusterSet in which it belongs.
-        ClusterClaims created on a managed cluster will be collected and saved into
-        the status of the corresponding ManagedCluster on hub.
+      description: ClusterClaim represents cluster information that a managed cluster claims ClusterClaims with well known names include,   1. id.k8s.io, it contains a unique identifier for the cluster.   2. clusterset.k8s.io, it contains an identifier that relates the cluster      to the ClusterSet in which it belongs. ClusterClaims created on a managed cluster will be collected and saved into the status of the corresponding ManagedCluster on hub.
       type: object
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -44,9 +35,9 @@ spec:
               minLength: 1
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1beta1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/cluster/v1beta1/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -9,244 +9,159 @@ spec:
     listKind: ManagedClusterSetList
     plural: managedclustersets
     shortNames:
-    - mclset
-    - mclsets
+      - mclset
+      - mclsets
     singular: managedclusterset
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    deprecated: true
-    deprecationWarning: "cluster.open-cluster-management.io/v1alpha1 ManagedClusterSet
-      is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSet"
-    schema:
-      openAPIV3Schema:
-        description: "ManagedClusterSet defines a group of ManagedClusters that user's
-          workload can run on. A workload can be defined to deployed on a ManagedClusterSet,
-          which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet
-          \  2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet
-          \  3. The service exposed by the workload can be shared in any ManagedCluster
-          in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian
-          ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset`
-          on the ManagedCluster to refers to the ManagedClusterSet. User is not allow
-          to add/remove this label on a ManagedCluster unless they have a RBAC rule
-          to CREATE on a virtual subresource of managedclustersets/join. In order
-          to update this label, user must have the permission on both the old and
-          new ManagedClusterSet."
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of the ManagedClusterSet
-            type: object
-          status:
-            description: Status represents the current status of the ManagedClusterSet
-            type: object
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this ManagedClusterSet.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="ClusterSetEmpty")].status
-      name: Empty
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: "ManagedClusterSet defines a group of ManagedClusters that user's
-          workload can run on. A workload can be defined to deployed on a ManagedClusterSet,
-          which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet
-          \  2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet
-          \  3. The service exposed by the workload can be shared in any ManagedCluster
-          in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian
-          ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset`
-          on the ManagedCluster to refers to the ManagedClusterSet. User is not allow
-          to add/remove this label on a ManagedCluster unless they have a RBAC rule
-          to CREATE on a virtual subresource of managedclustersets/join. In order
-          to update this label, user must have the permission on both the old and
-          new ManagedClusterSet."
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of the ManagedClusterSet
-            type: object
-          status:
-            description: Status represents the current status of the ManagedClusterSet
-            type: object
-            properties:
-              conditions:
-                description: Conditions contains the different condition statuses
-                  for this ManagedClusterSet.
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      deprecated: true
+      deprecationWarning: "cluster.open-cluster-management.io/v1alpha1 ManagedClusterSet is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSet"
+      schema:
+        openAPIV3Schema:
+          description: "ManagedClusterSet defines a group of ManagedClusters that user's workload can run on. A workload can be defined to deployed on a ManagedClusterSet, which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet   2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet   3. The service exposed by the workload can be shared in any ManagedCluster in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset` on the ManagedCluster to refers to the ManagedClusterSet. User is not allow to add/remove this label on a ManagedCluster unless they have a RBAC rule to CREATE on a virtual subresource of managedclustersets/join. In order to update this label, user must have the permission on both the old and new ManagedClusterSet."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ManagedClusterSet
+              type: object
+            status:
+              description: Status represents the current status of the ManagedClusterSet
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSet.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="ClusterSetEmpty")].status
+          name: Empty
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: "ManagedClusterSet defines a group of ManagedClusters that user's workload can run on. A workload can be defined to deployed on a ManagedClusterSet, which mean:   1. The workload can run on any ManagedCluster in the ManagedClusterSet   2. The workload cannot run on any ManagedCluster outside the ManagedClusterSet   3. The service exposed by the workload can be shared in any ManagedCluster in the ManagedClusterSet \n In order to assign a ManagedCluster to a certian ManagedClusterSet, add a label with name `cluster.open-cluster-management.io/clusterset` on the ManagedCluster to refers to the ManagedClusterSet. User is not allow to add/remove this label on a ManagedCluster unless they have a RBAC rule to CREATE on a virtual subresource of managedclustersets/join. In order to update this label, user must have the permission on both the old and new ManagedClusterSet."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ManagedClusterSet
+              type: object
+            status:
+              description: Status represents the current status of the ManagedClusterSet
+              type: object
+              properties:
+                conditions:
+                  description: Conditions contains the different condition statuses for this ManagedClusterSet.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/v1beta1/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/cluster/v1beta1/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -9,89 +9,62 @@ spec:
     listKind: ManagedClusterSetBindingList
     plural: managedclustersetbindings
     shortNames:
-    - mclsetbinding
-    - mclsetbindings
+      - mclsetbinding
+      - mclsetbindings
     singular: managedclustersetbinding
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    deprecated: true
-    deprecationWarning: "cluster.open-cluster-management.io/v1alpha1 ManagedClusterSetBinding
-      is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding"
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
-          certain namespace. User is able to create a ManagedClusterSetBinding in
-          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
-          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
-          created in the same namespace can only be distributed to ManagedClusters
-          in ManagedClusterSets bound in this namespace by higher level controllers.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of ManagedClusterSetBinding.
-            type: object
-            properties:
-              clusterSet:
-                description: ClusterSet is the name of the ManagedClusterSet to bind.
-                  It must match the instance name of the ManagedClusterSetBinding
-                  and cannot change once created. User is allowed to set this field
-                  if they have an RBAC rule to CREATE on the virtual subresource of
-                  managedclustersets/bind.
-                type: string
-                minLength: 1
-    served: true
-    storage: false
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
-          certain namespace. User is able to create a ManagedClusterSetBinding in
-          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
-          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
-          created in the same namespace can only be distributed to ManagedClusters
-          in ManagedClusterSets bound in this namespace by higher level controllers.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the attributes of ManagedClusterSetBinding.
-            type: object
-            properties:
-              clusterSet:
-                description: ClusterSet is the name of the ManagedClusterSet to bind.
-                  It must match the instance name of the ManagedClusterSetBinding
-                  and cannot change once created. User is allowed to set this field
-                  if they have an RBAC rule to CREATE on the virtual subresource of
-                  managedclustersets/bind.
-                type: string
-                minLength: 1
-    served: true
-    storage: true
+    - name: v1alpha1
+      deprecated: true
+      deprecationWarning: "cluster.open-cluster-management.io/v1alpha1 ManagedClusterSetBinding is deprecated; use cluster.open-cluster-management.io/v1beta1 ManagedClusterSetBinding"
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterSetBinding projects a ManagedClusterSet into a certain namespace. User is able to create a ManagedClusterSetBinding in a namespace and bind it to a ManagedClusterSet if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind. Workloads created in the same namespace can only be distributed to ManagedClusters in ManagedClusterSets bound in this namespace by higher level controllers.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of ManagedClusterSetBinding.
+              type: object
+              properties:
+                clusterSet:
+                  description: ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding and cannot change once created. User is allowed to set this field if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind.
+                  type: string
+                  minLength: 1
+      served: true
+      storage: false
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterSetBinding projects a ManagedClusterSet into a certain namespace. User is able to create a ManagedClusterSetBinding in a namespace and bind it to a ManagedClusterSet if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind. Workloads created in the same namespace can only be distributed to ManagedClusters in ManagedClusterSets bound in this namespace by higher level controllers.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of ManagedClusterSetBinding.
+              type: object
+              properties:
+                clusterSet:
+                  description: ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding and cannot change once created. User is allowed to set this field if they have an RBAC rule to CREATE on the virtual subresource of managedclustersets/bind.
+                  type: string
+                  minLength: 1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/dependencymagnet/doc.go
+++ b/dependencymagnet/doc.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // go mod won't pull in code that isn't depended upon, but we have some code we don't depend on from code that must be included

--- a/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -12,275 +12,186 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Klusterlet represents controllers on the managed cluster. When
-          configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig
-          in the same namespace to allow API requests to the hub for the registration
-          protocol.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents the desired deployment configuration of Klusterlet
-              agent.
-            type: object
-            properties:
-              clusterName:
-                description: ClusterName is the name of the managed cluster to be
-                  created on hub. The Klusterlet agent generates a random name if
-                  it is not set, or discovers the appropriate cluster name on OpenShift.
-                type: string
-              externalServerURLs:
-                description: ExternalServerURLs represents the a list of apiserver
-                  urls and ca bundles that is accessible externally If it is set empty,
-                  managed cluster has no externally accessible url that hub cluster
-                  can visit.
-                type: array
-                items:
-                  description: ServerURL represents the apiserver url and ca bundle
-                    that is accessible externally
-                  type: object
-                  properties:
-                    caBundle:
-                      description: CABundle is the ca bundle to connect to apiserver
-                        of the managed cluster. System certs are used if it is not
-                        set.
-                      type: string
-                      format: byte
-                    url:
-                      description: URL is the url of apiserver endpoint of the managed
-                        cluster.
-                      type: string
-              namespace:
-                description: Namespace is the namespace to deploy the agent. The namespace
-                  must have a prefix of "open-cluster-management-", and if it is not
-                  set, the namespace of "open-cluster-management-agent" is used to
-                  deploy agent.
-                type: string
-              nodePlacement:
-                description: NodePlacement enables explicit control over the scheduling
-                  of the deployed pods.
-                type: object
-                properties:
-                  nodeSelector:
-                    description: NodeSelector defines which Nodes the Pods are scheduled
-                      on. The default is an empty list.
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Klusterlet represents controllers on the managed cluster. When configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig in the same namespace to allow API requests to the hub for the registration protocol.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents the desired deployment configuration of Klusterlet agent.
+              type: object
+              properties:
+                clusterName:
+                  description: ClusterName is the name of the managed cluster to be created on hub. The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
+                  type: string
+                externalServerURLs:
+                  description: ExternalServerURLs represents the a list of apiserver urls and ca bundles that is accessible externally If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
+                  type: array
+                  items:
+                    description: ServerURL represents the apiserver url and ca bundle that is accessible externally
                     type: object
-                    additionalProperties:
-                      type: string
-                  tolerations:
-                    description: Tolerations is attached by pods to tolerate any taint
-                      that matches the triple <key,value,effect> using the matching
-                      operator <operator>. The default is an empty list.
-                    type: array
-                    items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                    properties:
+                      caBundle:
+                        description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                        type: string
+                        format: byte
+                      url:
+                        description: URL is the url of apiserver endpoint of the managed cluster.
+                        type: string
+                namespace:
+                  description: Namespace is the namespace to deploy the agent. The namespace must have a prefix of "open-cluster-management-", and if it is not set, the namespace of "open-cluster-management-agent" is used to deploy agent.
+                  type: string
+                nodePlacement:
+                  description: NodePlacement enables explicit control over the scheduling of the deployed pods.
+                  type: object
+                  properties:
+                    nodeSelector:
+                      description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
                       type: object
-                      properties:
-                        effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
-                          type: string
-                        key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
-                          type: string
-                        operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
-                          type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          type: integer
-                          format: int64
-                        value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
-                          type: string
-              registrationImagePullSpec:
-                description: RegistrationImagePullSpec represents the desired image
-                  configuration of registration agent.
-                type: string
-              workImagePullSpec:
-                description: WorkImagePullSpec represents the desired image configuration
-                  of work agent.
-                type: string
-          status:
-            description: Status represents the current status of Klusterlet agent.
-            type: object
-            properties:
-              conditions:
-                description: 'Conditions contain the different condition statuses
-                  for this Klusterlet. Valid condition types are: Applied: Components
-                  have been applied in the managed cluster. Available: Components
-                  in the managed cluster are available and ready to serve. Progressing:
-                  Components in the managed cluster are in a transitioning state.
-                  Degraded: Components in the managed cluster do not match the desired
-                  configuration and only provide degraded service.'
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              generations:
-                description: Generations are used to determine when an item needs
-                  to be reconciled or has changed in a way that needs a reaction.
-                type: array
-                items:
-                  description: GenerationStatus keeps track of the generation for
-                    a given resource so that decisions about forced updates can be
-                    made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
-                  type: object
-                  properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    lastGeneration:
-                      description: lastGeneration is the last generation of the resource
-                        that controller applies
-                      type: integer
-                      format: int64
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the resource that you're tracking
-                        is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the resource that you're
-                        tracking
-                      type: string
-              observedGeneration:
-                description: ObservedGeneration is the last generation change you've
-                  dealt with
-                type: integer
-                format: int64
-              relatedResources:
-                description: RelatedResources are used to track the resources that
-                  are related to this Klusterlet.
-                type: array
-                items:
-                  description: RelatedResourceMeta represents the resource that is
-                    managed by an operator
-                  type: object
-                  properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the thing you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the thing you're tracking
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                registrationImagePullSpec:
+                  description: RegistrationImagePullSpec represents the desired image configuration of registration agent.
+                  type: string
+                workImagePullSpec:
+                  description: WorkImagePullSpec represents the desired image configuration of work agent.
+                  type: string
+            status:
+              description: Status represents the current status of Klusterlet agent.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contain the different condition statuses for this Klusterlet. Valid condition types are: Applied: Components have been applied in the managed cluster. Available: Components in the managed cluster are available and ready to serve. Progressing: Components in the managed cluster are in a transitioning state. Degraded: Components in the managed cluster do not match the desired configuration and only provide degraded service.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                generations:
+                  description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the resource that controller applies
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the resource that you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the resource that you're tracking
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                relatedResources:
+                  description: RelatedResources are used to track the resources that are related to this Klusterlet.
+                  type: array
+                  items:
+                    description: RelatedResourceMeta represents the resource that is managed by an operator
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the thing you're tracking
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -12,249 +12,172 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ClusterManager configures the controllers on the hub that govern
-          registration and work distribution for attached Klusterlets. ClusterManager
-          will only be deployed in open-cluster-management-hub namespace.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents a desired deployment configuration of controllers
-              that govern registration and work distribution for attached Klusterlets.
-            type: object
-            properties:
-              nodePlacement:
-                description: NodePlacement enables explicit control over the scheduling
-                  of the deployed pods.
-                type: object
-                properties:
-                  nodeSelector:
-                    description: NodeSelector defines which Nodes the Pods are scheduled
-                      on. The default is an empty list.
-                    type: object
-                    additionalProperties:
-                      type: string
-                  tolerations:
-                    description: Tolerations is attached by pods to tolerate any taint
-                      that matches the triple <key,value,effect> using the matching
-                      operator <operator>. The default is an empty list.
-                    type: array
-                    items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterManager configures the controllers on the hub that govern registration and work distribution for attached Klusterlets. ClusterManager will only be deployed in open-cluster-management-hub namespace.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired deployment configuration of controllers that govern registration and work distribution for attached Klusterlets.
+              type: object
+              properties:
+                nodePlacement:
+                  description: NodePlacement enables explicit control over the scheduling of the deployed pods.
+                  type: object
+                  properties:
+                    nodeSelector:
+                      description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
                       type: object
-                      properties:
-                        effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
-                          type: string
-                        key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
-                          type: string
-                        operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
-                          type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          type: integer
-                          format: int64
-                        value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
-                          type: string
-              placementImagePullSpec:
-                description: PlacementImagePullSpec represents the desired image configuration
-                  of placement controller/webhook installed on hub.
-                type: string
-                default: quay.io/open-cluster-management/placement
-              registrationImagePullSpec:
-                description: RegistrationImagePullSpec represents the desired image
-                  of registration controller/webhook installed on hub.
-                type: string
-                default: quay.io/open-cluster-management/registration
-              workImagePullSpec:
-                description: WorkImagePullSpec represents the desired image configuration
-                  of work controller/webhook installed on hub.
-                type: string
-                default: quay.io/open-cluster-management/work
-          status:
-            description: Status represents the current status of controllers that
-              govern the lifecycle of managed clusters.
-            type: object
-            properties:
-              conditions:
-                description: 'Conditions contain the different condition statuses
-                  for this ClusterManager. Valid condition types are: Applied: Components
-                  in hub are applied. Available: Components in hub are available and
-                  ready to serve. Progressing: Components in hub are in a transitioning
-                  state. Degraded: Components in hub do not match the desired configuration
-                  and only provide degraded service.'
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              generations:
-                description: Generations are used to determine when an item needs
-                  to be reconciled or has changed in a way that needs a reaction.
-                type: array
-                items:
-                  description: GenerationStatus keeps track of the generation for
-                    a given resource so that decisions about forced updates can be
-                    made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
-                  type: object
-                  properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    lastGeneration:
-                      description: lastGeneration is the last generation of the resource
-                        that controller applies
-                      type: integer
-                      format: int64
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the resource that you're tracking
-                        is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the resource that you're
-                        tracking
-                      type: string
-              observedGeneration:
-                description: ObservedGeneration is the last generation change you've
-                  dealt with
-                type: integer
-                format: int64
-              relatedResources:
-                description: RelatedResources are used to track the resources that
-                  are related to this ClusterManager.
-                type: array
-                items:
-                  description: RelatedResourceMeta represents the resource that is
-                    managed by an operator
-                  type: object
-                  properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the thing you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the thing you're tracking
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                placementImagePullSpec:
+                  description: PlacementImagePullSpec represents the desired image configuration of placement controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/placement
+                registrationImagePullSpec:
+                  description: RegistrationImagePullSpec represents the desired image of registration controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/registration
+                workImagePullSpec:
+                  description: WorkImagePullSpec represents the desired image configuration of work controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/work
+            status:
+              description: Status represents the current status of controllers that govern the lifecycle of managed clusters.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contain the different condition statuses for this ClusterManager. Valid condition types are: Applied: Components in hub are applied. Available: Components in hub are available and ready to serve. Progressing: Components in hub are in a transitioning state. Degraded: Components in hub do not match the desired configuration and only provide degraded service.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                generations:
+                  description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the resource that controller applies
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the resource that you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the resource that you're tracking
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                relatedResources:
+                  description: RelatedResources are used to track the resources that are related to this ClusterManager.
+                  type: array
+                  items:
+                    description: RelatedResourceMeta represents the resource that is managed by an operator
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the thing you're tracking
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/operator/v1/0001_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0001_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -15,180 +15,111 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: Klusterlet represents controllers on the managed cluster. When
-        configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig
-        in the same namespace to allow API requests to the hub for the registration
-        protocol.
+      description: Klusterlet represents controllers on the managed cluster. When configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig in the same namespace to allow API requests to the hub for the registration protocol.
       type: object
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: Spec represents the desired deployment configuration of Klusterlet
-            agent.
+          description: Spec represents the desired deployment configuration of Klusterlet agent.
           type: object
           properties:
             clusterName:
-              description: ClusterName is the name of the managed cluster to be created
-                on hub. The Klusterlet agent generates a random name if it is not
-                set, or discovers the appropriate cluster name on OpenShift.
+              description: ClusterName is the name of the managed cluster to be created on hub. The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
               type: string
             externalServerURLs:
-              description: ExternalServerURLs represents the a list of apiserver urls
-                and ca bundles that is accessible externally If it is set empty, managed
-                cluster has no externally accessible url that hub cluster can visit.
+              description: ExternalServerURLs represents the a list of apiserver urls and ca bundles that is accessible externally If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
               type: array
               items:
-                description: ServerURL represents the apiserver url and ca bundle
-                  that is accessible externally
+                description: ServerURL represents the apiserver url and ca bundle that is accessible externally
                 type: object
                 properties:
                   caBundle:
-                    description: CABundle is the ca bundle to connect to apiserver
-                      of the managed cluster. System certs are used if it is not set.
+                    description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
                     type: string
                     format: byte
                   url:
-                    description: URL is the url of apiserver endpoint of the managed
-                      cluster.
+                    description: URL is the url of apiserver endpoint of the managed cluster.
                     type: string
             namespace:
-              description: Namespace is the namespace to deploy the agent. The namespace
-                must have a prefix of "open-cluster-management-", and if it is not
-                set, the namespace of "open-cluster-management-agent" is used to deploy
-                agent.
+              description: Namespace is the namespace to deploy the agent. The namespace must have a prefix of "open-cluster-management-", and if it is not set, the namespace of "open-cluster-management-agent" is used to deploy agent.
               type: string
             nodePlacement:
-              description: NodePlacement enables explicit control over the scheduling
-                of the deployed pods.
+              description: NodePlacement enables explicit control over the scheduling of the deployed pods.
               type: object
               properties:
                 nodeSelector:
-                  description: NodeSelector defines which Nodes the Pods are scheduled
-                    on. The default is an empty list.
+                  description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
                   type: object
                   additionalProperties:
                     type: string
                 tolerations:
-                  description: Tolerations is attached by pods to tolerate any taint
-                    that matches the triple <key,value,effect> using the matching
-                    operator <operator>. The default is an empty list.
+                  description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
                   type: array
                   items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
+                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                     type: object
                     properties:
                       effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
+                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                         type: string
                       operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
+                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
+                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                         type: integer
                         format: int64
                       value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
+                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                         type: string
             registrationImagePullSpec:
-              description: RegistrationImagePullSpec represents the desired image
-                configuration of registration agent.
+              description: RegistrationImagePullSpec represents the desired image configuration of registration agent.
               type: string
             workImagePullSpec:
-              description: WorkImagePullSpec represents the desired image configuration
-                of work agent.
+              description: WorkImagePullSpec represents the desired image configuration of work agent.
               type: string
         status:
           description: Status represents the current status of Klusterlet agent.
           type: object
           properties:
             conditions:
-              description: 'Conditions contain the different condition statuses for
-                this Klusterlet. Valid condition types are: Applied: Components have
-                been applied in the managed cluster. Available: Components in the
-                managed cluster are available and ready to serve. Progressing: Components
-                in the managed cluster are in a transitioning state. Degraded: Components
-                in the managed cluster do not match the desired configuration and
-                only provide degraded service.'
+              description: 'Conditions contain the different condition statuses for this Klusterlet. Valid condition types are: Applied: Components have been applied in the managed cluster. Available: Components in the managed cluster are available and ready to serve. Progressing: Components in the managed cluster are in a transitioning state. Degraded: Components in the managed cluster do not match the desired configuration and only provide degraded service.'
               type: array
               items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
+                description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                 type: object
                 required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                 properties:
                   lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
+                    description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                     type: string
                     format: date-time
                   message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
+                    description: message is a human readable message indicating details about the transition. This may be an empty string.
                     type: string
                     maxLength: 32768
                   observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
+                    description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                     type: integer
                     format: int64
                     minimum: 0
                   reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
+                    description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                     type: string
                     maxLength: 1024
                     minLength: 1
@@ -197,63 +128,49 @@ spec:
                     description: status of the condition, one of True, False, Unknown.
                     type: string
                     enum:
-                    - "True"
-                    - "False"
-                    - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                   type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                     type: string
                     maxLength: 316
                     pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
             generations:
-              description: Generations are used to determine when an item needs to
-                be reconciled or has changed in a way that needs a reaction.
+              description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
               type: array
               items:
-                description: GenerationStatus keeps track of the generation for a
-                  given resource so that decisions about forced updates can be made.
-                  The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
                 type: object
                 properties:
                   group:
                     description: group is the group of the resource that you're tracking
                     type: string
                   lastGeneration:
-                    description: lastGeneration is the last generation of the resource
-                      that controller applies
+                    description: lastGeneration is the last generation of the resource that controller applies
                     type: integer
                     format: int64
                   name:
                     description: name is the name of the resource that you're tracking
                     type: string
                   namespace:
-                    description: namespace is where the resource that you're tracking
-                      is
+                    description: namespace is where the resource that you're tracking is
                     type: string
                   resource:
-                    description: resource is the resource type of the resource that
-                      you're tracking
+                    description: resource is the resource type of the resource that you're tracking
                     type: string
                   version:
-                    description: version is the version of the resource that you're
-                      tracking
+                    description: version is the version of the resource that you're tracking
                     type: string
             observedGeneration:
-              description: ObservedGeneration is the last generation change you've
-                dealt with
+              description: ObservedGeneration is the last generation change you've dealt with
               type: integer
               format: int64
             relatedResources:
-              description: RelatedResources are used to track the resources that are
-                related to this Klusterlet.
+              description: RelatedResources are used to track the resources that are related to this Klusterlet.
               type: array
               items:
-                description: RelatedResourceMeta represents the resource that is managed
-                  by an operator
+                description: RelatedResourceMeta represents the resource that is managed by an operator
                 type: object
                 properties:
                   group:
@@ -266,17 +183,16 @@ spec:
                     description: namespace is where the thing you're tracking is
                     type: string
                   resource:
-                    description: resource is the resource type of the resource that
-                      you're tracking
+                    description: resource is the resource type of the resource that you're tracking
                     type: string
                   version:
                     description: version is the version of the thing you're tracking
                     type: string
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
   preserveUnknownFields: false
 status:
   acceptedNames:

--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -12,313 +12,200 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ManifestWork represents a manifests workload that hub wants to
-          deploy on the managed cluster. A manifest workload is defined as a set of
-          Kubernetes resources. ManifestWork must be created in the cluster namespace
-          on the hub, so that agent on the corresponding managed cluster can access
-          this resource and deploy on the managed cluster.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents a desired configuration of work to be deployed
-              on the managed cluster.
-            type: object
-            properties:
-              deleteOption:
-                description: DeleteOption represents deletion strategy when the manifestwork
-                  is deleted. Foreground deletion strategy is applied to all the resource
-                  in this manifestwork if it is not set.
-                type: object
-                properties:
-                  propagationPolicy:
-                    description: propagationPolicy can be Foreground, Orphan or SelectivelyOrphan
-                      SelectivelyOrphan should be rarely used.  It is provided for
-                      cases where particular resources is transfering ownership from
-                      one ManifestWork to another or another management unit. Setting
-                      this value will allow a flow like 1. create manifestwork/2 to
-                      manage foo 2. update manifestwork/1 to selectively orphan foo
-                      3. remove foo from manifestwork/1 without impacting continuity
-                      because manifestwork/2 adopts it.
-                    type: string
-                    default: ForeGround
-                  selectivelyOrphans:
-                    description: selectivelyOrphan represents a list of resources
-                      following orphan deletion stratecy
-                    type: object
-                    properties:
-                      orphaningRules:
-                        description: orphaningRules defines a slice of orphaningrule.
-                          Each orphaningrule identifies a single resource included
-                          in this manifestwork
-                        type: array
-                        items:
-                          description: OrphaningRule identifies a single resource
-                            included in this manifestwork
-                          type: object
-                          properties:
-                            group:
-                              description: Group is the api group of the resources
-                                in the workload that the strategy is applied
-                              type: string
-                            name:
-                              description: Name is the names of the resources in the
-                                workload that the strategy is applied
-                              type: string
-                            namespace:
-                              description: Namespace is the namespaces of the resources
-                                in the workload that the strategy is applied
-                              type: string
-                            resource:
-                              description: Resource is the resources in the workload
-                                that the strategy is applied
-                              type: string
-              workload:
-                description: Workload represents the manifest workload to be deployed
-                  on a managed cluster.
-                type: object
-                properties:
-                  manifests:
-                    description: Manifests represents a list of kuberenetes resources
-                      to be deployed on a managed cluster.
-                    type: array
-                    items:
-                      description: Manifest represents a resource to be deployed on
-                        managed cluster.
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-embedded-resource: true
-          status:
-            description: Status represents the current status of work.
-            type: object
-            properties:
-              conditions:
-                description: 'Conditions contains the different condition statuses
-                  for this work. Valid condition types are: 1. Applied represents
-                  workload in ManifestWork is applied successfully on managed cluster.
-                  2. Progressing represents workload in ManifestWork is being applied
-                  on managed cluster. 3. Available represents workload in ManifestWork
-                  exists on the managed cluster. 4. Degraded represents the current
-                  state of workload does not match the desired state for a certain
-                  period.'
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ManifestWork represents a manifests workload that hub wants to deploy on the managed cluster. A manifest workload is defined as a set of Kubernetes resources. ManifestWork must be created in the cluster namespace on the hub, so that agent on the corresponding managed cluster can access this resource and deploy on the managed cluster.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired configuration of work to be deployed on the managed cluster.
+              type: object
+              properties:
+                deleteOption:
+                  description: DeleteOption represents deletion strategy when the manifestwork is deleted. Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
                   type: object
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                    propagationPolicy:
+                      description: propagationPolicy can be Foreground, Orphan or SelectivelyOrphan SelectivelyOrphan should be rarely used.  It is provided for cases where particular resources is transfering ownership from one ManifestWork to another or another management unit. Setting this value will allow a flow like 1. create manifestwork/2 to manage foo 2. update manifestwork/1 to selectively orphan foo 3. remove foo from manifestwork/1 without impacting continuity because manifestwork/2 adopts it.
                       type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              resourceStatus:
-                description: ResourceStatus represents the status of each resource
-                  in manifestwork deployed on a managed cluster. The Klusterlet agent
-                  on managed cluster syncs the condition from the managed cluster
-                  to the hub.
-                type: object
-                properties:
-                  manifests:
-                    description: 'Manifests represents the condition of manifests
-                      deployed on managed cluster. Valid condition types are: 1. Progressing
-                      represents the resource is being applied on managed cluster.
-                      2. Applied represents the resource is applied successfully on
-                      managed cluster. 3. Available represents the resource exists
-                      on the managed cluster. 4. Degraded represents the current state
-                      of resource does not match the desired state for a certain period.'
-                    type: array
-                    items:
-                      description: ManifestCondition represents the conditions of
-                        the resources deployed on a managed cluster.
+                      default: ForeGround
+                    selectivelyOrphans:
+                      description: selectivelyOrphan represents a list of resources following orphan deletion stratecy
                       type: object
                       properties:
-                        conditions:
-                          description: Conditions represents the conditions of this
-                            resource on a managed cluster.
+                        orphaningRules:
+                          description: orphaningRules defines a slice of orphaningrule. Each orphaningrule identifies a single resource included in this manifestwork
                           type: array
                           items:
-                            description: "Condition contains details for one aspect
-                              of the current state of this API Resource. --- This
-                              struct is intended for direct use as an array at the
-                              field path .status.conditions.  For example, type FooStatus
-                              struct{     // Represents the observations of a foo's
-                              current state.     // Known .status.conditions.type
-                              are: \"Available\", \"Progressing\", and \"Degraded\"
-                              \    // +patchMergeKey=type     // +patchStrategy=merge
-                              \    // +listType=map     // +listMapKey=type     Conditions
-                              []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                              patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                              \n     // other fields }"
+                            description: OrphaningRule identifies a single resource included in this manifestwork
                             type: object
-                            required:
-                            - lastTransitionTime
-                            - message
-                            - reason
-                            - status
-                            - type
                             properties:
-                              lastTransitionTime:
-                                description: lastTransitionTime is the last time the
-                                  condition transitioned from one status to another.
-                                  This should be when the underlying condition changed.  If
-                                  that is not known, then using the time when the
-                                  API field changed is acceptable.
+                              group:
+                                description: Group is the api group of the resources in the workload that the strategy is applied
                                 type: string
-                                format: date-time
-                              message:
-                                description: message is a human readable message indicating
-                                  details about the transition. This may be an empty
-                                  string.
+                              name:
+                                description: Name is the names of the resources in the workload that the strategy is applied
                                 type: string
-                                maxLength: 32768
-                              observedGeneration:
-                                description: observedGeneration represents the .metadata.generation
-                                  that the condition was set based upon. For instance,
-                                  if .metadata.generation is currently 12, but the
-                                  .status.conditions[x].observedGeneration is 9, the
-                                  condition is out of date with respect to the current
-                                  state of the instance.
+                              namespace:
+                                description: Namespace is the namespaces of the resources in the workload that the strategy is applied
+                                type: string
+                              resource:
+                                description: Resource is the resources in the workload that the strategy is applied
+                                type: string
+                workload:
+                  description: Workload represents the manifest workload to be deployed on a managed cluster.
+                  type: object
+                  properties:
+                    manifests:
+                      description: Manifests represents a list of kuberenetes resources to be deployed on a managed cluster.
+                      type: array
+                      items:
+                        description: Manifest represents a resource to be deployed on managed cluster.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        x-kubernetes-embedded-resource: true
+            status:
+              description: Status represents the current status of work.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contains the different condition statuses for this work. Valid condition types are: 1. Applied represents workload in ManifestWork is applied successfully on managed cluster. 2. Progressing represents workload in ManifestWork is being applied on managed cluster. 3. Available represents workload in ManifestWork exists on the managed cluster. 4. Degraded represents the current state of workload does not match the desired state for a certain period.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                resourceStatus:
+                  description: ResourceStatus represents the status of each resource in manifestwork deployed on a managed cluster. The Klusterlet agent on managed cluster syncs the condition from the managed cluster to the hub.
+                  type: object
+                  properties:
+                    manifests:
+                      description: 'Manifests represents the condition of manifests deployed on managed cluster. Valid condition types are: 1. Progressing represents the resource is being applied on managed cluster. 2. Applied represents the resource is applied successfully on managed cluster. 3. Available represents the resource exists on the managed cluster. 4. Degraded represents the current state of resource does not match the desired state for a certain period.'
+                      type: array
+                      items:
+                        description: ManifestCondition represents the conditions of the resources deployed on a managed cluster.
+                        type: object
+                        properties:
+                          conditions:
+                            description: Conditions represents the conditions of this resource on a managed cluster.
+                            type: array
+                            items:
+                              description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                              type: object
+                              required:
+                                - lastTransitionTime
+                                - message
+                                - reason
+                                - status
+                                - type
+                              properties:
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                  type: string
+                                  format: date-time
+                                message:
+                                  description: message is a human readable message indicating details about the transition. This may be an empty string.
+                                  type: string
+                                  maxLength: 32768
+                                observedGeneration:
+                                  description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                                  type: integer
+                                  format: int64
+                                  minimum: 0
+                                reason:
+                                  description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                                  type: string
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                status:
+                                  description: status of the condition, one of True, False, Unknown.
+                                  type: string
+                                  enum:
+                                    - "True"
+                                    - "False"
+                                    - Unknown
+                                type:
+                                  description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                  type: string
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          resourceMeta:
+                            description: ResourceMeta represents the group, version, kind, name and namespace of a resoure.
+                            type: object
+                            properties:
+                              group:
+                                description: Group is the API Group of the Kubernetes resource.
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Kubernetes resource.
+                                type: string
+                              name:
+                                description: Name is the name of the Kubernetes resource.
+                                type: string
+                              namespace:
+                                description: Name is the namespace of the Kubernetes resource.
+                                type: string
+                              ordinal:
+                                description: Ordinal represents the index of the manifest on spec.
                                 type: integer
-                                format: int64
-                                minimum: 0
-                              reason:
-                                description: reason contains a programmatic identifier
-                                  indicating the reason for the condition's last transition.
-                                  Producers of specific condition types may define
-                                  expected values and meanings for this field, and
-                                  whether the values are considered a guaranteed API.
-                                  The value should be a CamelCase string. This field
-                                  may not be empty.
+                                format: int32
+                              resource:
+                                description: Resource is the resource name of the Kubernetes resource.
                                 type: string
-                                maxLength: 1024
-                                minLength: 1
-                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                              status:
-                                description: status of the condition, one of True,
-                                  False, Unknown.
+                              version:
+                                description: Version is the version of the Kubernetes resource.
                                 type: string
-                                enum:
-                                - "True"
-                                - "False"
-                                - Unknown
-                              type:
-                                description: type of condition in CamelCase or in
-                                  foo.example.com/CamelCase. --- Many .condition.type
-                                  values are consistent across resources like Available,
-                                  but because arbitrary conditions can be useful (see
-                                  .node.status.conditions), the ability to deconflict
-                                  is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                                type: string
-                                maxLength: 316
-                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        resourceMeta:
-                          description: ResourceMeta represents the group, version,
-                            kind, name and namespace of a resoure.
-                          type: object
-                          properties:
-                            group:
-                              description: Group is the API Group of the Kubernetes
-                                resource.
-                              type: string
-                            kind:
-                              description: Kind is the kind of the Kubernetes resource.
-                              type: string
-                            name:
-                              description: Name is the name of the Kubernetes resource.
-                              type: string
-                            namespace:
-                              description: Name is the namespace of the Kubernetes
-                                resource.
-                              type: string
-                            ordinal:
-                              description: Ordinal represents the index of the manifest
-                                on spec.
-                              type: integer
-                              format: int32
-                            resource:
-                              description: Resource is the resource name of the Kubernetes
-                                resource.
-                              type: string
-                            version:
-                              description: Version is the version of the Kubernetes
-                                resource.
-                              type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/work/v1/0000_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
+++ b/work/v1/0000_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
@@ -12,91 +12,63 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: AppliedManifestWork represents an applied manifestwork on managed
-          cluster that is placed on a managed cluster. An AppliedManifestWork links
-          to a manifestwork on a hub recording resources deployed in the managed cluster.
-          When the agent is removed from managed cluster, cluster-admin on managed
-          cluster can delete appliedmanifestwork to remove resources deployed by the
-          agent. The name of the appliedmanifestwork must be in the format of {hash
-          of hub's first kube-apiserver url}-{manifestwork name}
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents the desired configuration of AppliedManifestWork.
-            type: object
-            properties:
-              hubHash:
-                description: HubHash represents the hash of the first hub kube apiserver
-                  to identify which hub this AppliedManifestWork links to.
-                type: string
-              manifestWorkName:
-                description: ManifestWorkName represents the name of the related manifestwork
-                  on the hub.
-                type: string
-          status:
-            description: Status represents the current status of AppliedManifestWork.
-            type: object
-            properties:
-              appliedResources:
-                description: AppliedResources represents a list of resources defined
-                  within the manifestwork that are applied. Only resources with valid
-                  GroupVersionResource, namespace, and name are suitable. An item
-                  in this slice is deleted when there is no mapped manifest in manifestwork.Spec
-                  or by finalizer. The resource relating to the item will also be
-                  removed from managed cluster. The deleted resource may still be
-                  present until the finalizers for that resource are finished. However,
-                  the resource will not be undeleted, so it can be removed from this
-                  list and eventual consistency is preserved.
-                type: array
-                items:
-                  description: AppliedManifestResourceMeta represents the group, version,
-                    resource, name and namespace of a resource. Since these resources
-                    have been created, they must have valid group, version, resource,
-                    namespace, and name.
-                  type: object
-                  properties:
-                    group:
-                      description: Group is the API Group of the Kubernetes resource.
-                      type: string
-                    name:
-                      description: Name is the name of the Kubernetes resource.
-                      type: string
-                    namespace:
-                      description: Name is the namespace of the Kubernetes resource,
-                        empty string indicates it is a cluster scoped resource.
-                      type: string
-                    resource:
-                      description: Resource is the resource name of the Kubernetes
-                        resource.
-                      type: string
-                    uid:
-                      description: UID is set on successful deletion of the Kubernetes
-                        resource by controller. The resource might be still visible
-                        on the managed cluster after this field is set. It is not
-                        directly settable by a client.
-                      type: string
-                    version:
-                      description: Version is the version of the Kubernetes resource.
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: AppliedManifestWork represents an applied manifestwork on managed cluster that is placed on a managed cluster. An AppliedManifestWork links to a manifestwork on a hub recording resources deployed in the managed cluster. When the agent is removed from managed cluster, cluster-admin on managed cluster can delete appliedmanifestwork to remove resources deployed by the agent. The name of the appliedmanifestwork must be in the format of {hash of hub's first kube-apiserver url}-{manifestwork name}
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents the desired configuration of AppliedManifestWork.
+              type: object
+              properties:
+                hubHash:
+                  description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
+                  type: string
+                manifestWorkName:
+                  description: ManifestWorkName represents the name of the related manifestwork on the hub.
+                  type: string
+            status:
+              description: Status represents the current status of AppliedManifestWork.
+              type: object
+              properties:
+                appliedResources:
+                  description: AppliedResources represents a list of resources defined within the manifestwork that are applied. Only resources with valid GroupVersionResource, namespace, and name are suitable. An item in this slice is deleted when there is no mapped manifest in manifestwork.Spec or by finalizer. The resource relating to the item will also be removed from managed cluster. The deleted resource may still be present until the finalizers for that resource are finished. However, the resource will not be undeleted, so it can be removed from this list and eventual consistency is preserved.
+                  type: array
+                  items:
+                    description: AppliedManifestResourceMeta represents the group, version, resource, name and namespace of a resource. Since these resources have been created, they must have valid group, version, resource, namespace, and name.
+                    type: object
+                    properties:
+                      group:
+                        description: Group is the API Group of the Kubernetes resource.
+                        type: string
+                      name:
+                        description: Name is the name of the Kubernetes resource.
+                        type: string
+                      namespace:
+                        description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
+                        type: string
+                      resource:
+                        description: Resource is the resource name of the Kubernetes resource.
+                        type: string
+                      uid:
+                        description: UID is set on successful deletion of the Kubernetes resource by controller. The resource might be still visible on the managed cluster after this field is set. It is not directly settable by a client.
+                        type: string
+                      version:
+                        description: Version is the version of the Kubernetes resource.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/work/v1/0001_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
+++ b/work/v1/0001_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
@@ -16,24 +16,14 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: AppliedManifestWork represents an applied manifestwork on managed
-        cluster that is placed on a managed cluster. An AppliedManifestWork links
-        to a manifestwork on a hub recording resources deployed in the managed cluster.
-        When the agent is removed from managed cluster, cluster-admin on managed cluster
-        can delete appliedmanifestwork to remove resources deployed by the agent.
-        The name of the appliedmanifestwork must be in the format of {hash of hub's
-        first kube-apiserver url}-{manifestwork name}
+      description: AppliedManifestWork represents an applied manifestwork on managed cluster that is placed on a managed cluster. An AppliedManifestWork links to a manifestwork on a hub recording resources deployed in the managed cluster. When the agent is removed from managed cluster, cluster-admin on managed cluster can delete appliedmanifestwork to remove resources deployed by the agent. The name of the appliedmanifestwork must be in the format of {hash of hub's first kube-apiserver url}-{manifestwork name}
       type: object
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -42,33 +32,20 @@ spec:
           type: object
           properties:
             hubHash:
-              description: HubHash represents the hash of the first hub kube apiserver
-                to identify which hub this AppliedManifestWork links to.
+              description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
               type: string
             manifestWorkName:
-              description: ManifestWorkName represents the name of the related manifestwork
-                on the hub.
+              description: ManifestWorkName represents the name of the related manifestwork on the hub.
               type: string
         status:
           description: Status represents the current status of AppliedManifestWork.
           type: object
           properties:
             appliedResources:
-              description: AppliedResources represents a list of resources defined
-                within the manifestwork that are applied. Only resources with valid
-                GroupVersionResource, namespace, and name are suitable. An item in
-                this slice is deleted when there is no mapped manifest in manifestwork.Spec
-                or by finalizer. The resource relating to the item will also be removed
-                from managed cluster. The deleted resource may still be present until
-                the finalizers for that resource are finished. However, the resource
-                will not be undeleted, so it can be removed from this list and eventual
-                consistency is preserved.
+              description: AppliedResources represents a list of resources defined within the manifestwork that are applied. Only resources with valid GroupVersionResource, namespace, and name are suitable. An item in this slice is deleted when there is no mapped manifest in manifestwork.Spec or by finalizer. The resource relating to the item will also be removed from managed cluster. The deleted resource may still be present until the finalizers for that resource are finished. However, the resource will not be undeleted, so it can be removed from this list and eventual consistency is preserved.
               type: array
               items:
-                description: AppliedManifestResourceMeta represents the group, version,
-                  resource, name and namespace of a resource. Since these resources
-                  have been created, they must have valid group, version, resource,
-                  namespace, and name.
+                description: AppliedManifestResourceMeta represents the group, version, resource, name and namespace of a resource. Since these resources have been created, they must have valid group, version, resource, namespace, and name.
                 type: object
                 properties:
                   group:
@@ -78,26 +55,22 @@ spec:
                     description: Name is the name of the Kubernetes resource.
                     type: string
                   namespace:
-                    description: Name is the namespace of the Kubernetes resource,
-                      empty string indicates it is a cluster scoped resource.
+                    description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
                     type: string
                   resource:
                     description: Resource is the resource name of the Kubernetes resource.
                     type: string
                   uid:
-                    description: UID is set on successful deletion of the Kubernetes
-                      resource by controller. The resource might be still visible
-                      on the managed cluster after this field is set. It is not directly
-                      settable by a client.
+                    description: UID is set on successful deletion of the Kubernetes resource by controller. The resource might be still visible on the managed cluster after this field is set. It is not directly settable by a client.
                     type: string
                   version:
                     description: Version is the version of the Kubernetes resource.
                     type: string
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
In PR https://github.com/open-cluster-management-io/api/pull/109, introduce `+kubebuilder:validation:Minimum:=-10` to check negative integer, while the v0.2.5 controller-gen doesn't support negative integer yet.

So create this PR to request upgrading the version to v0.6.0, as the negative integer support is available since https://github.com/openshift/kubernetes-sigs-controller-tools/pull/8  .

Some breaking changes from v0.2.5 to v0.6.0 are listed in https://github.com/kubernetes-sigs/controller-tools/releases , need the reviewers to help validate. 
(do not want to upgrade to v0.7.0 as it remove support for legacy v1beta1 CRDs and webhooks )

### Breaking Changes

**v0.4.0**
- Default CRD generation version to v1 (#468)
- Add admissionregisteration/v1 support for webhook (#469)

**v0.4.1**
- Add AdmissionReviewVersions support for webhook (#474)

**v0.5.0**
- Update dependencies to Kubernetes v1.20.2 (#538)

**v0.6.0**
- Update Kubernetes 1.21.1 and Go 1.16 (#565, #576)
- Generate Embedded ObjectMeta in the CRDs, plus addressed comments (#557)

Signed-off-by: haoqing0110 <qhao@redhat.com>