### PR TITLE
Bugfix: Health check mode `omitempty`

### DIFF
--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -165,7 +165,7 @@ type HealthCheck struct {
 	// mode indicates which mode will be used to check the healthiness status of the addon.
 	// +optional
 	// +kubebuilder:default=Lease
-	Mode HealthCheckMode `json:"mode"`
+	Mode HealthCheckMode `json:"mode,omitempty"`
 }
 
 // ManagedClusterAddOnList is a list of ManagedClusterAddOn resources.


### PR DESCRIPTION
> Signed-off-by: yue9944882 <291271447@qq.com>

otherwise, after marshalling a empty healthcheck mode (which should be logically defaulted to `Lease`) to yaml, the mode field will become an empty string which constantly fails CRD validation.

/cc @qiujian16 @skeeey  

```
              },
              Status: "Failure",
              Message: "ManagedClusterAddOn.addon.open-cluster-management.io \"addon-n86c2\" is invalid: status.healthCheck.mode: Unsupported value: \"\": supported values: \"Lease\", \"Customized\"",
```