### PR TITLE
Expose the clusters and clusterSets getter controller runtime implementation

### DIFF
--- a/cluster/v1beta1/helpers.go
+++ b/cluster/v1beta1/helpers.go
@@ -1,23 +1,58 @@
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ManagedClusterGetter interface {
+type ManagedClustersGetter interface {
 	List(selector labels.Selector) (ret []*v1.ManagedCluster, err error)
 }
 
-type ManagedClusterSetGetter interface {
+type ManagedClusterSetsGetter interface {
 	List(selector labels.Selector) (ret []*ManagedClusterSet, err error)
 }
 
+type ManagedClustersGetterControllerRuntimeImpl struct {
+	client client.Client
+}
+type ManagedClusterSetsGetterControllerRuntimeImpl struct {
+	client client.Client
+}
+
+func (mcl ManagedClustersGetterControllerRuntimeImpl) List(selector labels.Selector) ([]*v1.ManagedCluster, error) {
+	clusterList := v1.ManagedClusterList{}
+	err := mcl.client.List(context.Background(), &clusterList, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	var retClusters []*v1.ManagedCluster
+	for i := range clusterList.Items {
+		retClusters = append(retClusters, &clusterList.Items[i])
+	}
+	return retClusters, nil
+}
+
+func (msl ManagedClusterSetsGetterControllerRuntimeImpl) List(selector labels.Selector) ([]*ManagedClusterSet, error) {
+	clusterSetList := ManagedClusterSetList{}
+	err := msl.client.List(context.Background(), &clusterSetList, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	var retClusterSets []*ManagedClusterSet
+	for i := range clusterSetList.Items {
+		retClusterSets = append(retClusterSets, &clusterSetList.Items[i])
+	}
+	return retClusterSets, nil
+}
+
 // GetClustersFromClusterSet return the ManagedClusterSet's managedClusters
-func GetClustersFromClusterSet(clusterSet *ManagedClusterSet, clusterGetter ManagedClusterGetter) ([]*v1.ManagedCluster, error) {
+func GetClustersFromClusterSet(clusterSet *ManagedClusterSet, clusterGetter ManagedClustersGetter) ([]*v1.ManagedCluster, error) {
 	var clusters []*v1.ManagedCluster
 
 	if clusterSet == nil {
@@ -39,7 +74,7 @@ func GetClustersFromClusterSet(clusterSet *ManagedClusterSet, clusterGetter Mana
 }
 
 // GetClusterSetsOfClusterByCluster return the managedClusterSets of a managedCluster
-func GetClusterSetsOfCluster(cluster *v1.ManagedCluster, clusterSetGetter ManagedClusterSetGetter) ([]*ManagedClusterSet, error) {
+func GetClusterSetsOfCluster(cluster *v1.ManagedCluster, clusterSetGetter ManagedClusterSetsGetter) ([]*ManagedClusterSet, error) {
 	var returnClusterSets []*ManagedClusterSet
 
 	if cluster == nil {


### PR DESCRIPTION
Also changed `ManagedClusterGetter` => `ManagedClustersGetter` and `ManagedClusterSetGetter` => `ManagedClusterSetsGetter` to match convention. 

Signed-off-by: Mike Ng <ming@redhat.com>