### PR TITLE
Add GetClusterSetName to get the name of the ManagedClusterSet from the ManagedCluster's clusterSet label.

### DIFF
--- a/cluster/v1beta1/helpers.go
+++ b/cluster/v1beta1/helpers.go
@@ -9,6 +9,10 @@ import (
 	v1 "open-cluster-management.io/api/cluster/v1"
 )
 
+const (
+	clusterSetLabel = "cluster.open-cluster-management.io/clusterset"
+)
+
 type ManagedClustersGetter interface {
 	List(selector labels.Selector) (ret []*v1.ManagedCluster, err error)
 }
@@ -107,4 +111,18 @@ func GetBoundManagedClusterSetBindings(namespace string,
 	}
 
 	return boundBindings, nil
+}
+
+// GetClusterSetName returns the ManagedClusterSet name in the ManagedCluster's clusterSet label
+func GetClusterSetName(managedCluster v1.ManagedCluster) string {
+	labels := managedCluster.GetLabels()
+	if len(labels) == 0 {
+		return ""
+	}
+
+	if clusterSetName := labels[clusterSetLabel]; len(clusterSetName) > 0 {
+		return clusterSetName
+	}
+
+	return ""
 }

--- a/cluster/v1beta1/helpers_test.go
+++ b/cluster/v1beta1/helpers_test.go
@@ -466,3 +466,45 @@ func TestGetValidManagedClusterSetBindings(t *testing.T) {
 		}
 	}
 }
+
+func TestGetClusterSetName(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cluster              v1.ManagedCluster
+		expectClusterSetName string
+		expectError          bool
+	}{
+		{
+			name: "test cluster with clusterset label",
+			cluster: v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c1",
+					Labels: map[string]string{
+						"cluster.open-cluster-management.io/clusterset": "c1set",
+					},
+				},
+				Spec: v1.ManagedClusterSpec{},
+			},
+			expectClusterSetName: "c1set",
+		},
+		{
+			name: "test cluster without clusterset label",
+			cluster: v1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c2",
+				},
+				Spec: v1.ManagedClusterSpec{},
+			},
+			expectClusterSetName: "",
+		},
+	}
+
+	for _, test := range tests {
+		returnClusterSetName := GetClusterSetName(test.cluster)
+
+		if !reflect.DeepEqual(returnClusterSetName, test.expectClusterSetName) {
+			t.Errorf("Case: %v, Failed to run TestGetClusterSetName. Expect clusterSetName: %v, return clusterSetName: %v", test.name, test.expectClusterSetName, returnClusterSetName)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>