### PR TITLE
Register feature "V1beta1CSRAPICompatibility" into FateureGates

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -55,5 +55,6 @@ var DefaultSpokeRegistrationFeatureGates = map[featuregate.Feature]featuregate.F
 // feature keys for registration hub controller.  To add a new feature, define a key for it above and
 // add it here.
 var DefaultHubRegistrationFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DefaultClusterSet: {Default: false, PreRelease: featuregate.Alpha},
+	DefaultClusterSet:          {Default: false, PreRelease: featuregate.Alpha},
+	V1beta1CSRAPICompatibility: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
This is corresponding with [PR](https://github.com/open-cluster-management-io/registration/pull/259).

Register the V1beta1CSRAPICompatibility feature into DefaultHubRegistrationFeatureGates.

Signed-off-by: Promacanthus <promacanthus@gmail.com>