### PR TITLE
Disable placement scheduling annotation

### DIFF
--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -295,8 +295,7 @@ type PlacementList struct {
 
 const (
 	// PlacementDisableAnnotation is used to disable scheduling for a placement.
-	// The typical case is a placement is created in one hub cluster.
-	// But the placement is not designed to be running in the that hub cluster.
-	// It is designed to be running in the other clusters which are managed by that hub cluster.
+	// It is a experimental flag to let placement controller ignore this placement,
+	// so other placement consumers can chime in.
 	PlacementDisableAnnotation = "cluster.open-cluster-management.io/experimental-scheduling-disable"
 )

--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -295,8 +295,8 @@ type PlacementList struct {
 
 const (
 	// PlacementDisableAnnotation is used to disable scheduling for a placement.
-	// The typical case is a placement is created in the global hub cluster.
-	// But the placement is not designed to be running in the global hub cluster.
-	// It is designed to be running in the regional clusters.
+	// The typical case is a placement is created in one hub cluster.
+	// But the placement is not designed to be running in the that hub cluster.
+	// It is designed to be running in the other clusters which are managed by that hub cluster.
 	PlacementDisableAnnotation = "cluster.open-cluster-management.io/experimental-scheduling-disable"
 )

--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -292,3 +292,11 @@ type PlacementList struct {
 	// Items is a list of Placements.
 	Items []Placement `json:"items"`
 }
+
+const (
+	// PlacementDisableAnnotation is used to disable scheduling for a placement.
+	// The typical case is a placement is created in the global hub cluster.
+	// But the placement is not designed to be running in the global hub cluster.
+	// It is designed to be running in the regional clusters.
+	PlacementDisableAnnotation = "cluster.open-cluster-management.io/experimental-scheduling-disable"
+)


### PR DESCRIPTION
introduce cluster.open-cluster-management.io/placement-scheduling-disable annotation to allow disabling the scheduling. for example, in the global hub case, the global hub controller will propagate the placement to the regional hub cluster. the placement is not designed to run in the cluster where it was created. It is designed to run in the regional hub cluster.

ref: https://github.com/stolostron/backlog/issues/25857

Signed-off-by: clyang82 <chuyang@redhat.com>