### PR TITLE
Fix broken make target update-with-container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@ RUN curl -LO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf go${GO_VERSION}.linux-amd64.tar.gz
-RUN go get -u -v golang.org/x/tools/cmd/...
+RUN go install golang.org/x/tools/cmd/...@latest
 
 RUN dnf -y install make git unzip findutils
 RUN curl -LO  https://github.com/google/protobuf/releases/download/v3.0.2/protoc-3.0.2-linux-x86_64.zip && \


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Fix issue:
```
 => ERROR [3/5] RUN go get -u -v golang.org/x/tools/cmd/...                                                                                    0.2s
------
 > [3/5] RUN go get -u -v golang.org/x/tools/cmd/...:
#5 0.211 go: go.mod file not found in current directory or any parent directory.
#5 0.211        'go get' is no longer supported outside a module.
#5 0.211        To build and install a command, use 'go install' with a version,
#5 0.211        like 'go install example.com/cmd@latest'
#5 0.211  For more information, see https://golang.org/doc/go-get-install-deprecation
#5 0.211  or run 'go help get' or 'go help install'.
------
executor failed running [/bin/sh -c go get -u -v golang.org/x/tools/cmd/...]: exit code: 1
make: *** [build-runtime-image] Error 1
```