### PR TITLE
Add agentID in AppliedManifestWork

### DIFF
--- a/work/v1/0000_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
+++ b/work/v1/0000_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
@@ -30,6 +30,9 @@ spec:
               description: Spec represents the desired configuration of AppliedManifestWork.
               type: object
               properties:
+                agentID:
+                  description: AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.
+                  type: string
                 hubHash:
                   description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
                   type: string

--- a/work/v1/0001_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
+++ b/work/v1/0001_01_work.open-cluster-management.io_appliedmanifestworks.crd.yaml
@@ -31,6 +31,9 @@ spec:
           description: Spec represents the desired configuration of AppliedManifestWork.
           type: object
           properties:
+            agentID:
+              description: AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.
+              type: string
             hubHash:
               description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
               type: string

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -527,6 +527,9 @@ type AppliedManifestWorkSpec struct {
 	// +required
 	HubHash string `json:"hubHash"`
 
+	// AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.
+	AgentID string `json:"agentID"`
+
 	// ManifestWorkName represents the name of the related manifestwork on the hub.
 	// +required
 	ManifestWorkName string `json:"manifestWorkName"`

--- a/work/v1/zz_generated.swagger_doc_generated.go
+++ b/work/v1/zz_generated.swagger_doc_generated.go
@@ -44,6 +44,7 @@ func (AppliedManifestWorkList) SwaggerDoc() map[string]string {
 var map_AppliedManifestWorkSpec = map[string]string{
 	"":                 "AppliedManifestWorkSpec represents the desired configuration of AppliedManifestWork",
 	"hubHash":          "HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.",
+	"agentID":          "AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.",
 	"manifestWorkName": "ManifestWorkName represents the name of the related manifestwork on the hub.",
 }
 


### PR DESCRIPTION
This is handle the case that a work agent may
need to handle appliedmanifestworks with different hubhash values.

Signed-off-by: Jian Qiu <jqiu@redhat.com>