### PR TITLE
WIP:Remove default value of feature gate mode

### DIFF
--- a/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -117,14 +117,14 @@ spec:
                         type: object
                         required:
                           - feature
+                          - mode
                         properties:
                           feature:
                             description: Feature is the key of feature gate. e.g. featuregate/Foo.
                             type: string
                           mode:
-                            description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                            description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                             type: string
-                            default: Disable
                             enum:
                               - Enable
                               - Disable
@@ -142,14 +142,14 @@ spec:
                         type: object
                         required:
                           - feature
+                          - mode
                         properties:
                           feature:
                             description: Feature is the key of feature gate. e.g. featuregate/Foo.
                             type: string
                           mode:
-                            description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                            description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                             type: string
-                            default: Disable
                             enum:
                               - Enable
                               - Disable

--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -42,7 +42,7 @@ spec:
                     - mode
                   properties:
                     hosted:
-                      description: Hosted includes configurations we needs for clustermanager in the Hosted mode.
+                      description: Hosted includes configurations we need for clustermanager in the Hosted mode.
                       type: object
                       properties:
                         registrationWebhookConfiguration:
@@ -131,14 +131,14 @@ spec:
                         type: object
                         required:
                           - feature
+                          - mode
                         properties:
                           feature:
                             description: Feature is the key of feature gate. e.g. featuregate/Foo.
                             type: string
                           mode:
-                            description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                            description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                             type: string
-                            default: Disable
                             enum:
                               - Enable
                               - Disable
@@ -157,14 +157,14 @@ spec:
                         type: object
                         required:
                           - feature
+                          - mode
                         properties:
                           feature:
                             description: Feature is the key of feature gate. e.g. featuregate/Foo.
                             type: string
                           mode:
-                            description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                            description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                             type: string
-                            default: Disable
                             enum:
                               - Enable
                               - Disable

--- a/operator/v1/0001_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0001_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -117,14 +117,14 @@ spec:
                     type: object
                     required:
                       - feature
+                      - mode
                     properties:
                       feature:
                         description: Feature is the key of feature gate. e.g. featuregate/Foo.
                         type: string
                       mode:
-                        description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                        description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                         type: string
-                        default: Disable
                         enum:
                           - Enable
                           - Disable
@@ -142,14 +142,14 @@ spec:
                     type: object
                     required:
                       - feature
+                      - mode
                     properties:
                       feature:
                         description: Feature is the key of feature gate. e.g. featuregate/Foo.
                         type: string
                       mode:
-                        description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                        description: Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
                         type: string
-                        default: Disable
                         enum:
                           - Enable
                           - Disable

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -93,19 +93,19 @@ type FeatureGate struct {
 	// +required
 	Feature string `json:"feature"`
 
-	// Mode is either Enable, Disable, "" where "" is Disable by default.
+	// Mode is either Enable, Disable.
 	// In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
 	// In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
-	// +kubebuilder:default:=Disable
 	// +kubebuilder:validation:Enum:=Enable;Disable
-	// +optional
-	Mode FeatureGateModeType `json:"mode,omitempty"`
+	// +kubebuilder:validation:Required
+	// +required
+	Mode FeatureGateModeType `json:"mode"`
 }
 
+// FeatureGateModeType represents whether a feature is enabled or not, valid value could be "Enable", "Disable".
 type FeatureGateModeType string
 
 const (
-	// Valid FeatureGateModeType value is Enable, Disable.
 	FeatureGateModeTypeEnable  FeatureGateModeType = "Enable"
 	FeatureGateModeTypeDisable FeatureGateModeType = "Disable"
 )
@@ -166,7 +166,7 @@ type ClusterManagerDeployOption struct {
 	// +kubebuilder:validation:Enum=Default;Hosted
 	Mode InstallMode `json:"mode,omitempty"`
 
-	// Hosted includes configurations we needs for clustermanager in the Hosted mode.
+	// Hosted includes configurations we need for clustermanager in the Hosted mode.
 	// +optional
 	Hosted *HostedClusterManagerConfiguration `json:"hosted,omitempty"`
 }

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -24,7 +24,7 @@ func (ClusterManager) SwaggerDoc() map[string]string {
 var map_ClusterManagerDeployOption = map[string]string{
 	"":       "ClusterManagerDeployOption describes the deploy options for cluster-manager",
 	"mode":   "Mode can be Default or Hosted. In Default mode, the Hub is installed as a whole and all parts of Hub are deployed in the same cluster. In Hosted mode, only crd and configurations are installed on one cluster(defined as hub-cluster). Controllers run in another cluster (defined as management-cluster) and connect to the hub with the kubeconfig in secret of \"external-hub-kubeconfig\"(a kubeconfig of hub-cluster with cluster-admin permission). Note: Do not modify the Mode field once it's applied.",
-	"hosted": "Hosted includes configurations we needs for clustermanager in the Hosted mode.",
+	"hosted": "Hosted includes configurations we need for clustermanager in the Hosted mode.",
 }
 
 func (ClusterManagerDeployOption) SwaggerDoc() map[string]string {
@@ -70,7 +70,7 @@ func (ClusterManagerStatus) SwaggerDoc() map[string]string {
 
 var map_FeatureGate = map[string]string{
 	"feature": "Feature is the key of feature gate. e.g. featuregate/Foo.",
-	"mode":    "Mode is either Enable, Disable, \"\" where \"\" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to \"--featuregate/Foo=true\". In Disable mode, a valid feature gate `featuregate/Foo` will be set to \"--featuregate/Foo=false\".",
+	"mode":    "Mode is either Enable, Disable. In Enable mode, a valid feature gate `featuregate/Foo` will be set to \"--featuregate/Foo=true\". In Disable mode, a valid feature gate `featuregate/Foo` will be set to \"--featuregate/Foo=false\".",
 }
 
 func (FeatureGate) SwaggerDoc() map[string]string {

--- a/test/integration/clustermanager_test.go
+++ b/test/integration/clustermanager_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
@@ -211,9 +212,8 @@ var _ = Describe("ClusterManager API test with RegistrationConfiguration", func(
 				},
 			},
 		}
-		clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clusterManager.Spec.RegistrationConfiguration.FeatureGates[0].Mode).Should(Equal(operatorv1.FeatureGateModeTypeDisable))
+		_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
+		Expect(errors.IsInvalid(err)).To(BeTrue())
 	})
 
 	It("Create a cluster manager with wrong registration feature gate mode", func() {
@@ -299,9 +299,8 @@ var _ = Describe("ClusterManager API test with WorkConfiguration", func() {
 				},
 			},
 		}
-		clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clusterManager.Spec.WorkConfiguration.FeatureGates[0].Mode).Should(Equal(operatorv1.FeatureGateModeTypeDisable))
+		_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
+		Expect(errors.IsInvalid(err)).To(BeTrue())
 	})
 
 	It("Create a cluster manager with wrong work feature gate mode", func() {

--- a/test/integration/klusterlet_test.go
+++ b/test/integration/klusterlet_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
@@ -127,9 +128,8 @@ var _ = Describe("Klusterlet API test with WorkConfiguration", func() {
 				},
 			},
 		}
-		klusterlet, err := operatorClient.OperatorV1().Klusterlets().Create(context.TODO(), klusterlet, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(klusterlet.Spec.WorkConfiguration.FeatureGates[0].Mode).Should(Equal(operatorv1.FeatureGateModeTypeDisable))
+		_, err := operatorClient.OperatorV1().Klusterlets().Create(context.TODO(), klusterlet, metav1.CreateOptions{})
+		Expect(errors.IsInvalid(err)).To(BeTrue())
 	})
 
 	It("Create a klusterlet with wrong work feature gate mode", func() {


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
Remove the default value of feature gate mode. because if we want to import a managed cluster which Kubernetes version is <= 1.16, it will use v1beta1 CustomResourceDefinition, but the v1beta1 CustomResourceDefinition does not support `+kubebuilder:default`

~And the default value of the feature gate false is a little confusing. if we configure a feature specifically, In most cases, I think we want our specified feature to be enabled.~