### PR TITLE
Set omitempty on the ManifestWork UpdateStrategy field

### DIFF
--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -163,7 +163,7 @@ spec:
                             description: Resource is the resource name of the Kubernetes resource.
                             type: string
                       updateStrategy:
-                        description: UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set, optional
+                        description: UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set.
                         type: object
                         required:
                           - type

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -92,9 +92,9 @@ type ManifestConfigOption struct {
 	FeedbackRules []FeedbackRule `json:"feedbackRules,omitempty"`
 
 	// UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update
-	// if it is not set,
-	// optional
-	UpdateStrategy *UpdateStrategy `json:"updateStrategy"`
+	// if it is not set.
+	// +optional
+	UpdateStrategy *UpdateStrategy `json:"updateStrategy,omitempty"`
 }
 
 // ManifestWorkExecutor is the executor that applies the resources to the managed cluster. i.e. the

--- a/work/v1/zz_generated.swagger_doc_generated.go
+++ b/work/v1/zz_generated.swagger_doc_generated.go
@@ -133,7 +133,7 @@ var map_ManifestConfigOption = map[string]string{
 	"":                   "ManifestConfigOption represents the configurations of a manifest defined in workload field.",
 	"resourceIdentifier": "ResourceIdentifier represents the group, resource, name and namespace of a resoure. iff this refers to a resource not created by this manifest work, the related rules will not be executed.",
 	"feedbackRules":      "FeedbackRules defines what resource status field should be returned. If it is not set or empty, no feedback rules will be honored.",
-	"updateStrategy":     "UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set, optional",
+	"updateStrategy":     "UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set.",
 }
 
 func (ManifestConfigOption) SwaggerDoc() map[string]string {

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_placemanifestworks.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_placemanifestworks.crd.yaml
@@ -187,7 +187,7 @@ spec:
                                 description: Resource is the resource name of the Kubernetes resource.
                                 type: string
                           updateStrategy:
-                            description: UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set, optional
+                            description: UpdateStrategy defines the strategy to update this manifest. UpdateStrategy is Update if it is not set.
                             type: object
                             required:
                               - type


### PR DESCRIPTION
When a ManifestWork without UpdateStrategy set is marshalled into JSON, it causes the JSON value of "updateStrategy": null. This works on newer versions of Kubernetes, however, on older versions such as v1.19.16, the following error is returned when creating a ManifestWork: The ManifestWork "addon-config-policy-controller-pre-delete-hosting-cluster2" is invalid: spec.manifestConfigs.updateStrategy: Invalid value: "null": spec.manifestConfigs.updateStrategy in body must be of type object: "null"

The best way to avoid this is to add omitempty to the JSON tag so that it's completely not present in the JSON representation.

This bug was encountered when using a predelete hook in the addon framework. So this change will need to be updated in at least the addon framework and the work agent.

Relates:
https://issues.redhat.com/browse/ACM-3233
https://issues.redhat.com/browse/ACM-2923

Signed-off-by: mprahl <mprahl@users.noreply.github.com>