### PR TITLE
:bug: update RolloutStrategy embed struct

### DIFF
--- a/cluster/v1alpha1/types_rolloutstrategy.go
+++ b/cluster/v1alpha1/types_rolloutstrategy.go
@@ -75,22 +75,22 @@ type MandatoryDecisionGroups struct {
 // RolloutAll is a RolloutStrategy Type
 type RolloutAll struct {
 	// +optional
-	Timeout Timeout `json:",inline"`
+	Timeout `json:",inline"`
 }
 
 // RolloutProgressivePerGroup is a RolloutStrategy Type
 type RolloutProgressivePerGroup struct {
 	// +optional
-	MandatoryDecisionGroups MandatoryDecisionGroups `json:",inline"`
+	MandatoryDecisionGroups `json:",inline"`
 
 	// +optional
-	Timeout Timeout `json:",inline"`
+	Timeout `json:",inline"`
 }
 
 // RolloutProgressive is a RolloutStrategy Type
 type RolloutProgressive struct {
 	// +optional
-	MandatoryDecisionGroups MandatoryDecisionGroups `json:",inline"`
+	MandatoryDecisionGroups `json:",inline"`
 
 	// MaxConcurrency is the max number of clusters to deploy workload concurrently. The default value for MaxConcurrency is determined from the clustersPerDecisionGroup defined in the placement->DecisionStrategy.
 	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
@@ -99,5 +99,5 @@ type RolloutProgressive struct {
 	MaxConcurrency intstr.IntOrString `json:"maxConcurrency,omitempty"`
 
 	// +optional
-	Timeout Timeout `json:",inline"`
+	Timeout `json:",inline"`
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When I have the below code, found the timeout field will not be created/patched, always empty value, update the embed struct can fix the issue.
```
			ginkgo.By("update cma to rolling update with timeout")
			cma, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
			gomega.Expect(err).ToNot(gomega.HaveOccurred())
			cma.Spec.InstallStrategy.Placements[0].RolloutStrategy = clusterv1alpha1.RolloutStrategy{
				Type:        clusterv1alpha1.Progressive,
				Progressive: &clusterv1alpha1.RolloutProgressive{MaxConcurrency: intstr.FromString("50%"), Timeout: clusterv1alpha1.Timeout{Timeout: "2s"}},
			}
			patchClusterManagementAddOn(context.Background(), cma)
```

## Related issue(s)

Fixes #