### PR TITLE
🌱 Add "-ed" to `Succeed` enum in `RolloutStatus`

### DIFF
--- a/cluster/v1alpha1/helpers.go
+++ b/cluster/v1alpha1/helpers.go
@@ -27,8 +27,8 @@ const (
 	ToApply RolloutStatus = iota
 	// Progressing indicates that the resource's desired status is applied and last applied status is not updated.
 	Progressing
-	// Succeed indicates that the resource's desired status is applied and last applied status is successful.
-	Succeed
+	// Succeeded indicates that the resource's desired status is applied and last applied status is successful.
+	Succeeded
 	// Failed indicates that the resource's desired status is applied and last applied status has failed.
 	Failed
 	// TimeOut indicates that the rollout status is progressing or failed and the status remains
@@ -288,7 +288,7 @@ func determineRolloutStatusAndContinue(status ClusterRolloutStatus, timeout time
 	switch status.Status {
 	case ToApply:
 		return newStatus, true
-	case TimeOut, Succeed, Skip:
+	case TimeOut, Succeeded, Skip:
 		return newStatus, false
 	case Progressing, Failed:
 		timeOutTime := getTimeOutTime(status.LastTransitionTime, timeout)

--- a/cluster/v1alpha1/helpers_test.go
+++ b/cluster/v1alpha1/helpers_test.go
@@ -55,7 +55,7 @@ func TestGetRolloutCluster_All(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply, LastTransitionTime: &fakeTime_60s},
 					"cluster2": {Status: Progressing, LastTransitionTime: &fakeTime_60s},
-					"cluster3": {Status: Succeed, LastTransitionTime: &fakeTime_60s},
+					"cluster3": {Status: Succeeded, LastTransitionTime: &fakeTime_60s},
 					"cluster4": {Status: Failed, LastTransitionTime: &fakeTime_60s},
 					"cluster5": {Status: Failed, LastTransitionTime: &fakeTime_120s},
 					"cluster6": {},
@@ -85,7 +85,7 @@ func TestGetRolloutCluster_All(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply},
 					"cluster2": {Status: Progressing},
-					"cluster3": {Status: Succeed},
+					"cluster3": {Status: Succeeded},
 					"cluster4": {Status: Failed},
 					"cluster5": {},
 				}
@@ -112,7 +112,7 @@ func TestGetRolloutCluster_All(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply},
 					"cluster2": {Status: Progressing},
-					"cluster3": {Status: Succeed},
+					"cluster3": {Status: Succeeded},
 					"cluster4": {Status: Failed},
 					"cluster5": {},
 				}
@@ -182,7 +182,7 @@ func TestGetRolloutCluster_Progressive(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply, LastTransitionTime: &fakeTime_60s},
 					"cluster2": {Status: Progressing, LastTransitionTime: &fakeTime_60s},
-					"cluster3": {Status: Succeed, LastTransitionTime: &fakeTime_60s},
+					"cluster3": {Status: Succeeded, LastTransitionTime: &fakeTime_60s},
 					"cluster4": {Status: Failed, LastTransitionTime: &fakeTime_60s},
 					"cluster5": {Status: Failed, LastTransitionTime: &fakeTime_120s},
 					"cluster6": {},
@@ -223,7 +223,7 @@ func TestGetRolloutCluster_Progressive(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply},
 					"cluster2": {Status: Progressing},
-					"cluster3": {Status: Succeed},
+					"cluster3": {Status: Succeeded},
 					"cluster4": {Status: Failed},
 					"cluster5": {},
 				}
@@ -261,7 +261,7 @@ func TestGetRolloutCluster_Progressive(t *testing.T) {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
 					"cluster1": {Status: ToApply},
 					"cluster2": {Status: Progressing},
-					"cluster3": {Status: Succeed},
+					"cluster3": {Status: Succeeded},
 					"cluster4": {Status: Failed},
 					"cluster5": {},
 				}
@@ -349,10 +349,10 @@ func TestGetRolloutCluster_Progressive(t *testing.T) {
 			},
 			clusterRolloutStatusFunc: func(clusterName string) ClusterRolloutStatus {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
-					"cluster1": {Status: Succeed},
-					"cluster2": {Status: Succeed},
+					"cluster1": {Status: Succeeded},
+					"cluster2": {Status: Succeeded},
 					"cluster3": {Status: ToApply},
-					"cluster4": {Status: Succeed},
+					"cluster4": {Status: Succeeded},
 					"cluster5": {Status: ToApply},
 					"cluster6": {Status: ToApply},
 				}
@@ -636,10 +636,10 @@ func TestGetRolloutCluster_ProgressivePerGroup(t *testing.T) {
 			},
 			clusterRolloutStatusFunc: func(clusterName string) ClusterRolloutStatus {
 				clustersRolloutStatus := map[string]ClusterRolloutStatus{
-					"cluster1": {Status: Succeed},
-					"cluster2": {Status: Succeed},
+					"cluster1": {Status: Succeeded},
+					"cluster2": {Status: Succeeded},
 					"cluster3": {Status: ToApply},
-					"cluster4": {Status: Succeed},
+					"cluster4": {Status: Succeeded},
 					"cluster5": {Status: ToApply},
 				}
 				return clustersRolloutStatus[clusterName]
@@ -755,8 +755,8 @@ func TestNeedToUpdate(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "Succeed status",
-			status:         Succeed,
+			name:           "Succeeded status",
+			status:         Succeeded,
 			lastTransition: nil,
 			timeout:        time.Minute,
 			expectedResult: false,

--- a/cluster/v1beta1/helpers.go
+++ b/cluster/v1beta1/helpers.go
@@ -123,8 +123,8 @@ type PlacementDecisionClustersTracker struct {
 	placementDecisionGetter        PlacementDecisionGetter
 	existingScheduledClusters      sets.Set[string]
 	existingScheduledClusterGroups map[GroupKey]sets.Set[string]
-	clustesGroupsIndexToName       map[int32]string
-	clustesGroupsNameToIndex       map[string][]int32
+	clusterGroupsIndexToName       map[int32]string
+	clusterGroupsNameToIndex       map[string][]int32
 	lock                           sync.RWMutex
 }
 
@@ -195,22 +195,22 @@ func (pdct *PlacementDecisionClustersTracker) Get() (sets.Set[string], sets.Set[
 }
 
 func (pdct *PlacementDecisionClustersTracker) generateGroupsNameIndex() {
-	pdct.clustesGroupsIndexToName = map[int32]string{}
-	pdct.clustesGroupsNameToIndex = map[string][]int32{}
+	pdct.clusterGroupsIndexToName = map[int32]string{}
+	pdct.clusterGroupsNameToIndex = map[string][]int32{}
 
 	for groupkey := range pdct.existingScheduledClusterGroups {
 		// index to name
-		pdct.clustesGroupsIndexToName[groupkey.GroupIndex] = groupkey.GroupName
+		pdct.clusterGroupsIndexToName[groupkey.GroupIndex] = groupkey.GroupName
 		// name to index
-		if index, exist := pdct.clustesGroupsNameToIndex[groupkey.GroupName]; exist {
-			pdct.clustesGroupsNameToIndex[groupkey.GroupName] = append(index, groupkey.GroupIndex)
+		if index, exist := pdct.clusterGroupsNameToIndex[groupkey.GroupName]; exist {
+			pdct.clusterGroupsNameToIndex[groupkey.GroupName] = append(index, groupkey.GroupIndex)
 		} else {
-			pdct.clustesGroupsNameToIndex[groupkey.GroupName] = []int32{groupkey.GroupIndex}
+			pdct.clusterGroupsNameToIndex[groupkey.GroupName] = []int32{groupkey.GroupIndex}
 		}
 	}
 
 	// sort index order
-	for _, index := range pdct.clustesGroupsNameToIndex {
+	for _, index := range pdct.clusterGroupsNameToIndex {
 		sort.Slice(index, func(i, j int) bool {
 			return index[i] < index[j]
 		})
@@ -303,13 +303,13 @@ func (pdct *PlacementDecisionClustersTracker) fulfillGroupKeys(groupKeys []Group
 	fulfilledGroupKeys := []GroupKey{}
 	for _, gk := range groupKeys {
 		if gk.GroupName != "" {
-			if indexes, exist := pdct.clustesGroupsNameToIndex[gk.GroupName]; exist {
+			if indexes, exist := pdct.clusterGroupsNameToIndex[gk.GroupName]; exist {
 				for _, groupIndex := range indexes {
 					fulfilledGroupKeys = append(fulfilledGroupKeys, GroupKey{GroupName: gk.GroupName, GroupIndex: groupIndex})
 				}
 			}
 		} else {
-			if groupName, exist := pdct.clustesGroupsIndexToName[gk.GroupIndex]; exist {
+			if groupName, exist := pdct.clusterGroupsIndexToName[gk.GroupIndex]; exist {
 				fulfilledGroupKeys = append(fulfilledGroupKeys, GroupKey{GroupName: groupName, GroupIndex: gk.GroupIndex})
 			}
 		}
@@ -319,8 +319,8 @@ func (pdct *PlacementDecisionClustersTracker) fulfillGroupKeys(groupKeys []Group
 
 func (pdct *PlacementDecisionClustersTracker) getOrderedGroupKeysBesides(orderedGroupKeyToExclude []GroupKey) []GroupKey {
 	orderedGroupKey := []GroupKey{}
-	for i := 0; i < len(pdct.clustesGroupsIndexToName); i++ {
-		groupKey := GroupKey{GroupName: pdct.clustesGroupsIndexToName[int32(i)], GroupIndex: int32(i)}
+	for i := 0; i < len(pdct.clusterGroupsIndexToName); i++ {
+		groupKey := GroupKey{GroupName: pdct.clusterGroupsIndexToName[int32(i)], GroupIndex: int32(i)}
 		if !containsGroupKey(orderedGroupKeyToExclude, groupKey) {
 			orderedGroupKey = append(orderedGroupKey, groupKey)
 		}


### PR DESCRIPTION
<!--
:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization
-->
## Summary

- Add -ed to `Succeed` enum in `RolloutStatus`
- `clustesGroups` --> `clusterGroups`

## Related issue(s)

- #254 
