### PR TITLE
:seedling: Add `Ignore` rollout status

### DIFF
--- a/cluster/v1alpha1/helpers.go
+++ b/cluster/v1alpha1/helpers.go
@@ -33,6 +33,8 @@ const (
 	// TimeOut indicates that the rollout status is progressing or failed and the status remains
 	// for longer than the timeout, resulting in a timeout status.
 	TimeOut
+	// Ignore indicates that the resource's desired status is applied but the last applied status is irrelevant.
+	Ignore
 	// Skip indicates that the rollout should be skipped on this cluster.
 	Skip
 )
@@ -291,7 +293,7 @@ func determineRolloutStatusAndContinue(status ClusterRolloutStatus, timeout time
 	switch status.Status {
 	case ToApply:
 		return newStatus, true
-	case TimeOut, Succeeded, Skip:
+	case TimeOut, Succeeded, Skip, Ignore:
 		return newStatus, false
 	case Progressing, Failed:
 		timeOutTime := getTimeOutTime(status.LastTransitionTime, timeout)

--- a/cluster/v1alpha1/types_rolloutstrategy.go
+++ b/cluster/v1alpha1/types_rolloutstrategy.go
@@ -8,13 +8,15 @@ import (
 
 // RolloutStrategy API used by workload applier APIs to define how the workload will be applied to the selected clusters by the Placement and DecisionStrategy.
 
+type RolloutType string
+
 const (
 	//All means apply the workload to all clusters in the decision groups at once.
-	All string = "All"
+	All RolloutType = "All"
 	//Progressive means apply the workload to the selected clusters progressively per cluster.
-	Progressive string = "Progressive"
+	Progressive RolloutType = "Progressive"
 	//ProgressivePerGroup means apply the workload to the selected clusters progressively per group.
-	ProgressivePerGroup string = "ProgressivePerGroup"
+	ProgressivePerGroup RolloutType = "ProgressivePerGroup"
 )
 
 // Rollout strategy to apply workload to the selected clusters by Placement and DecisionStrategy.
@@ -26,7 +28,7 @@ type RolloutStrategy struct {
 	// +kubebuilder:validation:Enum=All;Progressive;ProgressivePerGroup
 	// +kubebuilder:default:=All
 	// +optional
-	Type string `json:"type,omitempty"`
+	Type RolloutType `json:"type,omitempty"`
 
 	// All define required fields for RolloutStrategy type All
 	// +optional


### PR DESCRIPTION
<!--
:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization
-->
## Summary

An `Ignore` rollout status in my reading of it felt different than a `Skip` status, where `Ignore` would mean that it wouldn't factor into a rollout but would receive updates while `Skip` would mean it didn't receive updates, but I'm open to discussion on it.

I also have an optional commit here to add `RolloutType` to make the enum a bit more concrete.

## Related issue(s)

- #254 