### PR TITLE
🐛 support update&updateStatus for manifestwork cloudevents client.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - release-*
+      - br_support_update_for_manifestwork_cloudevents_client
   workflow_dispatch: {}
   pull_request:
     branches:
       - main
       - release-*
+      - br_support_update_for_manifestwork_cloudevents_client
 
 env:
   # Common versions

--- a/test/integration/cloudevents/suite_test.go
+++ b/test/integration/cloudevents/suite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mochi-mqtt/server/v2/listeners"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog"
 
 	"open-cluster-management.io/api/cloudevents/generic"
 	"open-cluster-management.io/api/cloudevents/generic/options/mqtt"
@@ -31,6 +32,8 @@ var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
 
 	// start a MQTT broker
 	mqttBroker = mochimqtt.New(&mochimqtt.Options{})
+	l := mqttBroker.Log.Level(zerolog.DebugLevel)
+	mqttBroker.Log = &l
 	// allow all connections.
 	err := mqttBroker.AddHook(new(auth.AllowHook), nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -45,6 +48,7 @@ var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
 
 	mqttOptions = mqtt.NewMQTTOptions()
 	mqttOptions.BrokerHost = mqttBrokerHost
+	ginkgo.By("start an source")
 	sourceCloudEventsClient, err = source.StartResourceSourceClient(context.TODO(), mqttOptions)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR introduces the addition of 'Update' and 'UpdateStatus' functionalities for the manifestwork cloudevents client. These methods are necessary as the work-client implementation will use them, but currently the manifestwork cloudevents client only includes 'Get' and 'Patch'.
