### PR TITLE
:bug: run `make update` fail because deepcopy doesn't support generic …

### DIFF
--- a/cluster/v1alpha1/doc.go
+++ b/cluster/v1alpha1/doc.go
@@ -1,5 +1,4 @@
 // Package v1alpha1 contains API Schema definitions for the cluster v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=open-cluster-management.io/api/cluster
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:openapi-gen=true

--- a/cluster/v1alpha1/helpers.go
+++ b/cluster/v1alpha1/helpers.go
@@ -38,6 +38,7 @@ const (
 )
 
 // ClusterRolloutStatus holds the rollout status information for a cluster.
+// +k8s:deepcopy-gen=true
 type ClusterRolloutStatus struct {
 	// cluster name
 	ClusterName string
@@ -53,6 +54,7 @@ type ClusterRolloutStatus struct {
 }
 
 // RolloutResult contains list of clusters that are timeOut, removed and required to rollOut
+// +k8s:deepcopy-gen=true
 type RolloutResult struct {
 	// ClustersToRollout is a slice of ClusterRolloutStatus that will be rolled out.
 	ClustersToRollout []ClusterRolloutStatus

--- a/cluster/v1alpha1/types.go
+++ b/cluster/v1alpha1/types.go
@@ -7,6 +7,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:deepcopy-gen=true
 // +kubebuilder:resource:scope="Cluster"
 
 // ClusterClaim represents cluster information that a managed cluster claims
@@ -25,6 +26,7 @@ type ClusterClaim struct {
 	Spec ClusterClaimSpec `json:"spec,omitempty"`
 }
 
+// +k8s:deepcopy-gen=true
 type ClusterClaimSpec struct {
 	// Value is a claim-dependent string
 	// +kubebuilder:validation:MaxLength=1024
@@ -33,6 +35,7 @@ type ClusterClaimSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:deepcopy-gen=true
 
 // ClusterClaimList is a collection of ClusterClaim.
 type ClusterClaimList struct {

--- a/cluster/v1alpha1/types_addonplacementscore.go
+++ b/cluster/v1alpha1/types_addonplacementscore.go
@@ -6,6 +6,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:deepcopy-gen=true
 // +kubebuilder:resource:scope="Namespaced"
 // +kubebuilder:subresource:status
 
@@ -21,6 +22,7 @@ type AddOnPlacementScore struct {
 }
 
 // AddOnPlacementScoreStatus represents the current status of AddOnPlacementScore.
+// +k8s:deepcopy-gen=true
 type AddOnPlacementScoreStatus struct {
 	// Conditions contain the different condition statuses for this AddOnPlacementScore.
 	// +patchMergeKey=type
@@ -46,6 +48,7 @@ type AddOnPlacementScoreStatus struct {
 }
 
 // AddOnPlacementScoreItem represents the score name and value.
+// +k8s:deepcopy-gen=true
 type AddOnPlacementScoreItem struct {
 	// Name is the name of the score
 	// +kubebuilder:validation:Required
@@ -61,6 +64,7 @@ type AddOnPlacementScoreItem struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:deepcopy-gen=true
 
 // AddOnPlacementScoreList is a collection of AddOnPlacementScore.
 type AddOnPlacementScoreList struct {

--- a/cluster/v1alpha1/types_rolloutstrategy.go
+++ b/cluster/v1alpha1/types_rolloutstrategy.go
@@ -18,6 +18,7 @@ const (
 )
 
 // Rollout strategy to apply workload to the selected clusters by Placement and DecisionStrategy.
+// +k8s:deepcopy-gen=true
 type RolloutStrategy struct {
 	// Rollout strategy Types are All, Progressive and ProgressivePerGroup
 	// 1) All means apply the workload to all clusters in the decision groups at once.
@@ -42,6 +43,7 @@ type RolloutStrategy struct {
 }
 
 // Timeout to consider while applying the workload.
+// +k8s:deepcopy-gen=true
 type Timeout struct {
 	// Timeout define how long workload applier controller will wait till workload reach successful state in the cluster.
 	// Timeout default value is None meaning the workload applier will not proceed apply workload to other clusters if did not reach the successful state.
@@ -54,6 +56,7 @@ type Timeout struct {
 
 // MandatoryDecisionGroup set the decision group name or group index.
 // GroupName is considered first to select the decisionGroups then GroupIndex.
+// +k8s:deepcopy-gen=true
 type MandatoryDecisionGroup struct {
 	// GroupName of the decision group should match the placementDecisions label value with label key cluster.open-cluster-management.io/decision-group-name
 	// +optional
@@ -65,6 +68,7 @@ type MandatoryDecisionGroup struct {
 }
 
 // MandatoryDecisionGroups
+// +k8s:deepcopy-gen=true
 type MandatoryDecisionGroups struct {
 	// List of the decision groups names or indexes to apply the workload first and fail if workload did not reach successful state.
 	// GroupName or GroupIndex must match with the decisionGroups defined in the placement's decisionStrategy
@@ -73,12 +77,14 @@ type MandatoryDecisionGroups struct {
 }
 
 // RolloutAll is a RolloutStrategy Type
+// +k8s:deepcopy-gen=true
 type RolloutAll struct {
 	// +optional
 	Timeout `json:",inline"`
 }
 
 // RolloutProgressivePerGroup is a RolloutStrategy Type
+// +k8s:deepcopy-gen=true
 type RolloutProgressivePerGroup struct {
 	// +optional
 	MandatoryDecisionGroups `json:",inline"`
@@ -88,6 +94,7 @@ type RolloutProgressivePerGroup struct {
 }
 
 // RolloutProgressive is a RolloutStrategy Type
+// +k8s:deepcopy-gen=true
 type RolloutProgressive struct {
 	// +optional
 	MandatoryDecisionGroups `json:",inline"`

--- a/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -316,15 +316,22 @@ func (in *RolloutResult) DeepCopyInto(out *RolloutResult) {
 	if in.ClustersToRollout != nil {
 		in, out := &in.ClustersToRollout, &out.ClustersToRollout
 		*out = make([]ClusterRolloutStatus, len(*in))
-		for key, val := range *in {
-			(*out)[key] = *val.DeepCopy()
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.ClustersTimeOut != nil {
 		in, out := &in.ClustersTimeOut, &out.ClustersTimeOut
 		*out = make([]ClusterRolloutStatus, len(*in))
-		for key, val := range *in {
-			(*out)[key] = *val.DeepCopy()
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.ClustersRemoved != nil {
+		in, out := &in.ClustersRemoved, &out.ClustersRemoved
+		*out = make([]ClusterRolloutStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	return


### PR DESCRIPTION
…type.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->

## Summary

Run `make update` fail because of `deepcopy-gen` doesn't support generic type yet. https://github.com/kubernetes/gengo/issues/225

It will log errors:
```
W1017 14:10:32.195161   62703 parse.go:863] Making unsupported type entry "T" for: &types.TypeParam{check:(*types.Checker)(nil), id:0x1, obj:(*types.TypeName)(0xc009651900), index:0, bound:(*types.Interface)(0xc00009a960)}
F1017 14:10:32.221298   62703 deepcopy.go:890] Hit an unsupported type open-cluster-management.io/api/cluster/v1alpha1.ClusterRolloutStatusFunc[T] for open-cluster-management.io/api/cluster/v1alpha1.ClusterRolloutStatusFunc[T], from open-cluster-management.io/api/cluster/v1alpha1.RolloutHandler[T]
```

The generic type was introduced by this PR: https://github.com/open-cluster-management-io/api/pull/276

In this PR, we change the strategy from 'opt-out'(via `deepcopy-gen=false` comment) to 'opt-in'(via `deepcopy-gen=true` comment)

## Related issue(s)

Fixes #