### PR TITLE
:bug: fix default value 0 is a string type

### DIFF
--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -152,7 +152,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: "0"
+                                  default: 0
                                   description: MaxFailures is a percentage or number
                                     of clusters in the current rollout that can fail
                                     before proceeding to the next rollout. MaxFailures
@@ -249,7 +249,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: "0"
+                                  default: 0
                                   description: MaxFailures is a percentage or number
                                     of clusters in the current rollout that can fail
                                     before proceeding to the next rollout. MaxFailures
@@ -335,7 +335,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  default: "0"
+                                  default: 0
                                   description: MaxFailures is a percentage or number
                                     of clusters in the current rollout that can fail
                                     before proceeding to the next rollout. MaxFailures

--- a/cluster/v1alpha1/types_rolloutstrategy.go
+++ b/cluster/v1alpha1/types_rolloutstrategy.go
@@ -81,7 +81,7 @@ type RolloutConfig struct {
 	// Default is that no failures are tolerated.
 	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
 	// +kubebuilder:validation:XIntOrString
-	// +kubebuilder:default="0"
+	// +kubebuilder:default=0
 	// +optional
 	MaxFailures intstr.IntOrString `json:"maxFailures,omitempty"`
 	// Timeout defines how long the workload applier controller will wait until the workload reaches a

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -341,7 +341,7 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              default: "0"
+                              default: 0
                               description: MaxFailures is a percentage or number of
                                 clusters in the current rollout that can fail before
                                 proceeding to the next rollout. MaxFailures is only
@@ -435,7 +435,7 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              default: "0"
+                              default: 0
                               description: MaxFailures is a percentage or number of
                                 clusters in the current rollout that can fail before
                                 proceeding to the next rollout. MaxFailures is only
@@ -519,7 +519,7 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              default: "0"
+                              default: 0
                               description: MaxFailures is a percentage or number of
                                 clusters in the current rollout that can fail before
                                 proceeding to the next rollout. MaxFailures is only


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Fix the below error when `MaxFailures` field is not defined and use the default value. 
```
E1127 07:23:43.074771       1 base_controller.go:266] "addon-configuration-controller" controller failed to sync "managed-serviceaccount", err: failed to parse the provided maxFailures: '0' is an invalid maximum threshold value: string is not a percentage
```

## Related issue(s)

Fixes #