### PR TITLE
:sparkles: Add nodeStatus.

### DIFF
--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -263,6 +263,26 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeStatus:
+                description: NodeStatus represents the status of nodes on the managed
+                  cluster.
+                properties:
+                  ready:
+                    description: Ready represents the number of ready nodes on the
+                      managed cluster.
+                    format: int32
+                    type: integer
+                  schedulable:
+                    description: Schedulable represents the number of schedulable
+                      nodes on the managed cluster.
+                    format: int32
+                    type: integer
+                  total:
+                    description: Total represents the total number of nodes on the
+                      managed cluster.
+                    format: int32
+                    type: integer
+                type: object
               version:
                 description: Version represents the kubernetes version of the managed
                   cluster.

--- a/cluster/v1/types.go
+++ b/cluster/v1/types.go
@@ -163,6 +163,25 @@ type ManagedClusterStatus struct {
 	// vendor or version specific and may not be included from all managed clusters.
 	// +optional
 	ClusterClaims []ManagedClusterClaim `json:"clusterClaims,omitempty"`
+
+	// NodeStatus represents the status of nodes on the managed cluster.
+	// +optional
+	NodeStatus NodeStatus `json:"nodeStatus,omitempty"`
+}
+
+// NodeStatus represents the status of nodes on the managed cluster.
+type NodeStatus struct {
+	// Ready represents the number of ready nodes on the managed cluster.
+	// +optional
+	Ready int32 `json:"ready,omitempty"`
+
+	// Schedulable represents the number of schedulable nodes on the managed cluster.
+	// +optional
+	Schedulable int32 `json:"schedulable,omitempty"`
+
+	// Total represents the total number of nodes on the managed cluster.
+	// +optional
+	Total int32 `json:"total,omitempty"`
 }
 
 // ManagedClusterVersion represents version information about the managed cluster.

--- a/cluster/v1/zz_generated.swagger_doc_generated.go
+++ b/cluster/v1/zz_generated.swagger_doc_generated.go
@@ -70,6 +70,7 @@ var map_ManagedClusterStatus = map[string]string{
 	"allocatable":   "Allocatable represents the total allocatable resources on the managed cluster.",
 	"version":       "Version represents the kubernetes version of the managed cluster.",
 	"clusterClaims": "ClusterClaims represents cluster information that a managed cluster claims, for example a unique cluster identifier (id.k8s.io) and kubernetes version (kubeversion.open-cluster-management.io). They are written from the managed cluster. The set of claims is not uniform across a fleet, some claims can be vendor or version specific and may not be included from all managed clusters.",
+	"nodeStatus":    "NodeStatus represents the status of nodes on the managed cluster.",
 }
 
 func (ManagedClusterStatus) SwaggerDoc() map[string]string {
@@ -83,6 +84,17 @@ var map_ManagedClusterVersion = map[string]string{
 
 func (ManagedClusterVersion) SwaggerDoc() map[string]string {
 	return map_ManagedClusterVersion
+}
+
+var map_NodeStatus = map[string]string{
+	"":            "NodeStatus represents the status of nodes on the managed cluster.",
+	"ready":       "Ready represents the number of ready nodes on the managed cluster.",
+	"schedulable": "Schedulable represents the number of schedulable nodes on the managed cluster.",
+	"total":       "Total represents the total number of nodes on the managed cluster.",
+}
+
+func (NodeStatus) SwaggerDoc() map[string]string {
+	return map_NodeStatus
 }
 
 var map_Taint = map[string]string{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add node status section to represent ready, schedulable numbers of nodes on a managed cluster.

## Related issue(s)

Fixes #