### PR TITLE
:sparkles: Add ClientCertAdditionalData & HubSensitive

### DIFF
--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -309,6 +309,22 @@ spec:
                     addon agent to register to hub. The Klusterlet agent will create
                     a csr for the addon agent with the registrationConfig.
                   properties:
+                    clientCertAdditionalData:
+                      additionalProperties:
+                        type: string
+                      description: The signed CSR client certificates will be stored
+                        as a secret on the agent, clientCertAdditionalData is the
+                        additional data that will be stored alongside with the client
+                        certificate in that secret. Also, the change of the additional
+                        data will trigger the CSR renewal.
+                      type: object
+                    hubSensitive:
+                      default: true
+                      description: HubSensitive is a flag to indicate whether the
+                        registrationConfig is sensitive to the hub. If it is set to
+                        true, the renewal of the CSR will be triggered when the hub
+                        is changed.
+                      type: boolean
                     signerName:
                       description: signerName is the name of signer that addon agent
                         will use to create csr.

--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -68,6 +68,18 @@ type RegistrationConfig struct {
 	//
 	// +optional
 	Subject Subject `json:"subject,omitempty"`
+
+	// HubSensitive is a flag to indicate whether the registrationConfig is sensitive to the hub.
+	// If it is set to true, the renewal of the CSR will be triggered when the hub is changed.
+	// +optional
+	// +kubebuilder:default=true
+	HubSensitive bool `json:"hubSensitive,omitempty"`
+
+	// The signed CSR client certificates will be stored as a secret on the agent, clientCertAdditionalData
+	// is the additional data that will be stored alongside with the client certificate in that secret.
+	// Also, the change of the additional data will trigger the CSR renewal.
+	// +optional
+	ClientCertAdditionalData map[string]string `json:"clientCertAdditionalData,omitempty"`
 }
 
 type AddOnConfig struct {

--- a/addon/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/addon/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -415,9 +415,11 @@ func (ObjectReference) SwaggerDoc() map[string]string {
 }
 
 var map_RegistrationConfig = map[string]string{
-	"":           "RegistrationConfig defines the configuration of the addon agent to register to hub. The Klusterlet agent will create a csr for the addon agent with the registrationConfig.",
-	"signerName": "signerName is the name of signer that addon agent will use to create csr.",
-	"subject":    "subject is the user subject of the addon agent to be registered to the hub. If it is not set, the addon agent will have the default subject \"subject\": {\n  \"user\": \"system:open-cluster-management:cluster:{clusterName}:addon:{addonName}:agent:{agentName}\",\n  \"groups: [\"system:open-cluster-management:cluster:{clusterName}:addon:{addonName}\",\n            \"system:open-cluster-management:addon:{addonName}\", \"system:authenticated\"]\n}",
+	"":                         "RegistrationConfig defines the configuration of the addon agent to register to hub. The Klusterlet agent will create a csr for the addon agent with the registrationConfig.",
+	"signerName":               "signerName is the name of signer that addon agent will use to create csr.",
+	"subject":                  "subject is the user subject of the addon agent to be registered to the hub. If it is not set, the addon agent will have the default subject \"subject\": {\n  \"user\": \"system:open-cluster-management:cluster:{clusterName}:addon:{addonName}:agent:{agentName}\",\n  \"groups: [\"system:open-cluster-management:cluster:{clusterName}:addon:{addonName}\",\n            \"system:open-cluster-management:addon:{addonName}\", \"system:authenticated\"]\n}",
+	"hubSensitive":             "HubSensitive is a flag to indicate whether the registrationConfig is sensitive to the hub. If it is set to true, the renewal of the CSR will be triggered when the hub is changed.",
+	"clientCertAdditionalData": "The signed CSR client certificates will be stored as a secret on the agent, clientCertAdditionalData is the additional data that will be stored alongside with the client certificate in that secret. Also, the change of the additional data will trigger the CSR renewal.",
 }
 
 func (RegistrationConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`HubSensitive` by default is true, for [CustomSignedCSR like cluster-proxy](https://github.com/xuezhaojun/cluster-proxy/blob/b0cc356681b6ccb4e60f989b932b92854e1fed1e/pkg/proxyagent/agent/agent.go#L78-L79) , it will add an addtionalData of hub CA hash when storing certificates to a secert. So that hub change will trigger the renewal of CSR.

For addons that don't want CSR renewl when changing hub(for example, the client certificates is used to access a consist URL service), the addon developer can set the `HubSensitive` to false, and control the renewal of CSR by set their own `ClientCertAddtionalData`.