### PR TITLE
✨ add work driver config to cluster manager.

### DIFF
--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -323,6 +323,8 @@ spec:
                     type: string
                 type: object
               workConfiguration:
+                default:
+                  workDriver: kube
                 description: WorkConfiguration contains the configuration of work
                 properties:
                   featureGates:
@@ -356,6 +358,22 @@ spec:
                       - feature
                       type: object
                     type: array
+                  workDriver:
+                    default: kube
+                    description: "WorkDriver represents the type of work driver. Possible
+                      values are \"kube\", \"mqtt\", or \"grpc\". If not provided,
+                      the default value is \"kube\". If set to non-\"kube\" drivers,
+                      the klusterlet need to use the same driver. and the driver configuration
+                      must be provided in a secret named \"work-driver-config\" in
+                      the namespace where the cluster manager is running, adhering
+                      to the following structure: config.yaml: | <driver-config-in-yaml>
+                      \n For detailed driver configuration, please refer to the sdk-go
+                      documentation: https://github.com/open-cluster-management-io/sdk-go/blob/main/pkg/cloudevents/README.md#supported-protocols-and-drivers"
+                    enum:
+                    - kube
+                    - mqtt
+                    - grpc
+                    type: string
                 type: object
               workImagePullSpec:
                 default: quay.io/open-cluster-management/work

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -134,8 +134,20 @@ type WorkConfiguration struct {
 	// +optional
 	// +kubebuilder:default:=kube
 	// +kubebuilder:validation:Enum=kube;mqtt;grpc
-	WorkDriver string `json:"workDriver,omitempty"`
+	WorkDriver WorkDriverType `json:"workDriver,omitempty"`
 }
+
+// WorkDriverType represents the type of work driver.
+type WorkDriverType string
+
+const (
+	// WorkDriverTypeKube is the work driver type for kube.
+	WorkDriverTypeKube WorkDriverType = "kube"
+	// WorkDriverTypeMqtt is the work driver type for mqtt.
+	WorkDriverTypeMqtt WorkDriverType = "mqtt"
+	// WorkDriverTypeGrpc is the work driver type for grpc.
+	WorkDriverTypeGrpc WorkDriverType = "grpc"
+)
 
 type AddOnManagerConfiguration struct {
 	// FeatureGates represents the list of feature gates for addon manager

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -65,6 +65,7 @@ type ClusterManagerSpec struct {
 
 	// WorkConfiguration contains the configuration of work
 	// +optional
+	// +kubebuilder:default={workDriver: kube}
 	WorkConfiguration *WorkConfiguration `json:"workConfiguration,omitempty"`
 
 	// AddOnManagerConfiguration contains the configuration of addon manager
@@ -119,6 +120,21 @@ type WorkConfiguration struct {
 	//  	he can set featuregate/Foo=false before upgrading. Let's say the cluster-admin wants featuregate/Foo=false.
 	// +optional
 	FeatureGates []FeatureGate `json:"featureGates,omitempty"`
+
+	// WorkDriver represents the type of work driver. Possible values are "kube", "mqtt", or "grpc".
+	// If not provided, the default value is "kube".
+	// If set to non-"kube" drivers, the klusterlet need to use the same driver.
+	// and the driver configuration must be provided in a secret named "work-driver-config"
+	// in the namespace where the cluster manager is running, adhering to the following structure:
+	// config.yaml: |
+	//   <driver-config-in-yaml>
+	//
+	// For detailed driver configuration, please refer to the sdk-go documentation: https://github.com/open-cluster-management-io/sdk-go/blob/main/pkg/cloudevents/README.md#supported-protocols-and-drivers
+	//
+	// +optional
+	// +kubebuilder:default:=kube
+	// +kubebuilder:validation:Enum=kube;mqtt;grpc
+	WorkDriver string `json:"workDriver,omitempty"`
 }
 
 type AddOnManagerConfiguration struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -156,6 +156,7 @@ func (WebhookConfiguration) SwaggerDoc() map[string]string {
 
 var map_WorkConfiguration = map[string]string{
 	"featureGates": "FeatureGates represents the list of feature gates for work If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates:\n  1. If featuregate/Foo does not exist, registration-operator will discard it\n  2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true]\n  3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false,\n \the can set featuregate/Foo=false before upgrading. Let's say the cluster-admin wants featuregate/Foo=false.",
+	"workDriver":   "WorkDriver represents the type of work driver. Possible values are \"kube\", \"mqtt\", or \"grpc\". If not provided, the default value is \"kube\". If set to non-\"kube\" drivers, the klusterlet need to use the same driver. and the driver configuration must be provided in a secret named \"work-driver-config\" in the namespace where the cluster manager is running, adhering to the following structure: config.yaml: |\n  <driver-config-in-yaml>\n\nFor detailed driver configuration, please refer to the sdk-go documentation: https://github.com/open-cluster-management-io/sdk-go/blob/main/pkg/cloudevents/README.md#supported-protocols-and-drivers",
 }
 
 func (WorkConfiguration) SwaggerDoc() map[string]string {

--- a/test/integration/api/clustermanager_test.go
+++ b/test/integration/api/clustermanager_test.go
@@ -281,7 +281,22 @@ var _ = Describe("ClusterManager API test with WorkConfiguration", func() {
 		clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(clusterManager.Spec.WorkConfiguration).To(BeNil())
+		Expect(clusterManager.Spec.WorkConfiguration.WorkDriver).Should(Equal("kube"))
+	})
+
+	It("Create a cluster manager with wrong driver type", func() {
+		clusterManager := &operatorv1.ClusterManager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterManagerName,
+			},
+			Spec: operatorv1.ClusterManagerSpec{
+				WorkConfiguration: &operatorv1.WorkConfiguration{
+					WorkDriver: "WrongDriver",
+				},
+			},
+		}
+		_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("Create a cluster manager with empty work feature gate mode", func() {

--- a/test/integration/api/clustermanager_test.go
+++ b/test/integration/api/clustermanager_test.go
@@ -281,7 +281,7 @@ var _ = Describe("ClusterManager API test with WorkConfiguration", func() {
 		clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(clusterManager.Spec.WorkConfiguration.WorkDriver).Should(Equal("kube"))
+		Expect(clusterManager.Spec.WorkConfiguration.WorkDriver).Should(Equal(operatorv1.WorkDriverTypeKube))
 	})
 
 	It("Create a cluster manager with wrong driver type", func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds the capability to configure the work driver for the work controller via the cluster manager by adding work driver configuration.

## Related issue(s)

Fixes #