### PR TITLE
🌱 add cloudevents driver feature gate for manifestwork replicaset.

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -64,6 +64,10 @@ const (
 	// of clusters selected by a placement. For more info check ManifestWorkReplicaSet APIs
 	ManifestWorkReplicaSet featuregate.Feature = "ManifestWorkReplicaSet"
 
+	// ManifestWorkReplicaSetCloudEventsDrivers will enable the cloud events drivers (mqtt or grpc) for the
+	// ManifestWorkReplicaSet controller, so that the controller can send manifestworks through cloud events.
+	ManifestWorkReplicaSetCloudEventsDrivers featuregate.Feature = "ManifestWorkReplicaSetCloudEventsDrivers"
+
 	// RawFeedbackJsonString will make the work agent to return the feedback result as a json string if the result
 	// is not a scalar value.
 	RawFeedbackJsonString featuregate.Feature = "RawFeedbackJsonString"
@@ -98,8 +102,9 @@ var DefaultHubAddonManagerFeatureGates = map[featuregate.Feature]featuregate.Fea
 // DefaultHubWorkFeatureGates consists of all known acm work wehbook feature keys.
 // To add a new feature, define a key for it above and add it here.
 var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	NilExecutorValidating:  {Default: false, PreRelease: featuregate.Alpha},
-	ManifestWorkReplicaSet: {Default: false, PreRelease: featuregate.Alpha},
+	NilExecutorValidating:                    {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkReplicaSet:                   {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkReplicaSetCloudEventsDrivers: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultSpokeWorkFeatureGates consists of all known ocm work feature keys for work agent.

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -64,9 +64,9 @@ const (
 	// of clusters selected by a placement. For more info check ManifestWorkReplicaSet APIs
 	ManifestWorkReplicaSet featuregate.Feature = "ManifestWorkReplicaSet"
 
-	// ManifestWorkReplicaSetCloudEventsDrivers will enable the cloud events drivers (mqtt or grpc) for the
-	// ManifestWorkReplicaSet controller, so that the controller can send manifestworks through cloud events.
-	ManifestWorkReplicaSetCloudEventsDrivers featuregate.Feature = "ManifestWorkReplicaSetCloudEventsDrivers"
+	// CloudEventsDrivers will enable the cloud events drivers (mqtt or grpc) for the hub controller,
+	// so that the controller can deliver manifestworks to the managed clusters via cloud events.
+	CloudEventsDrivers featuregate.Feature = "CloudEventsDrivers"
 
 	// RawFeedbackJsonString will make the work agent to return the feedback result as a json string if the result
 	// is not a scalar value.
@@ -102,9 +102,9 @@ var DefaultHubAddonManagerFeatureGates = map[featuregate.Feature]featuregate.Fea
 // DefaultHubWorkFeatureGates consists of all known acm work wehbook feature keys.
 // To add a new feature, define a key for it above and add it here.
 var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	NilExecutorValidating:                    {Default: false, PreRelease: featuregate.Alpha},
-	ManifestWorkReplicaSet:                   {Default: false, PreRelease: featuregate.Alpha},
-	ManifestWorkReplicaSetCloudEventsDrivers: {Default: false, PreRelease: featuregate.Alpha},
+	NilExecutorValidating:  {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkReplicaSet: {Default: false, PreRelease: featuregate.Alpha},
+	CloudEventsDrivers:     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultSpokeWorkFeatureGates consists of all known ocm work feature keys for work agent.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR tries to add new feature gate to control whether cloudevents driver is enabled for manifestworkreplicaset controlller.

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/pull/381