### PR TITLE
:sparkles: Add `MultipleHubs` in the feature gate list.

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -74,6 +74,9 @@ const (
 
 	// ResourceCleanup will start gc controller to clean up resources in cluster ns after cluster is deleted.
 	ResourceCleanup featuregate.Feature = "ResourceCleanup"
+
+	// MultipleHubs allows user to configure multiple bootstrapkubeconfig connecting to different hubs via Klusterlet and let agent decide which one to use
+	MultipleHubs featuregate.Feature = "MultipleHubs"
 )
 
 // DefaultSpokeRegistrationFeatureGates consists of all known ocm-registration
@@ -83,6 +86,7 @@ var DefaultSpokeRegistrationFeatureGates = map[featuregate.Feature]featuregate.F
 	ClusterClaim:               {Default: true, PreRelease: featuregate.Beta},
 	AddonManagement:            {Default: true, PreRelease: featuregate.Alpha},
 	V1beta1CSRAPICompatibility: {Default: false, PreRelease: featuregate.Alpha},
+	MultipleHubs:               {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultHubRegistrationFeatureGates consists of all known ocm-registration


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The `MultipleHubs` is in alpha stage, is used by both operator and registration-agent.