### PR TITLE
:sparkles: Add MultipleHubs in default operator feature gates.

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -117,3 +117,9 @@ var DefaultSpokeWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSp
 	ExecutorValidatingCaches: {Default: false, PreRelease: featuregate.Alpha},
 	RawFeedbackJsonString:    {Default: false, PreRelease: featuregate.Alpha},
 }
+
+// DefaultSpokeOperatorFeatureGates consists of all known ocm operator feature keys for operator.
+// To add a new feature, define a key for it above and add it here.
+var DefaultSpokeOperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	MultipleHubs: {Default: false, PreRelease: featuregate.Alpha},
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR is related to the https://github.com/open-cluster-management-io/api/pull/331 we want to control this feature in both operator and registration part.