### PR TITLE
:book: chore: update part of the work api ReadOnly comment to clarify it's still possible to use status feedback

### DIFF
--- a/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -276,7 +276,8 @@ spec:
                                 ServerSideApply type means to update resource using server side apply with work-controller as the field manager.
                                 If there is conflict, the related Applied condition of manifest will be in the status of False with the
                                 reason of ApplyConflict.
-                                ReadOnly type means the agent will only check the existence of the resource based on its metadata.
+                                ReadOnly type means the agent will only check the existence of the resource based on its metadata,
+                                statusFeedBackRules can still be used to get feedbackResults.
                               enum:
                               - Update
                               - CreateOnly

--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -259,7 +259,8 @@ spec:
                             ServerSideApply type means to update resource using server side apply with work-controller as the field manager.
                             If there is conflict, the related Applied condition of manifest will be in the status of False with the
                             reason of ApplyConflict.
-                            ReadOnly type means the agent will only check the existence of the resource based on its metadata.
+                            ReadOnly type means the agent will only check the existence of the resource based on its metadata,
+                            statusFeedBackRules can still be used to get feedbackResults.
                           enum:
                           - Update
                           - CreateOnly

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -162,7 +162,8 @@ type UpdateStrategy struct {
 	// ServerSideApply type means to update resource using server side apply with work-controller as the field manager.
 	// If there is conflict, the related Applied condition of manifest will be in the status of False with the
 	// reason of ApplyConflict.
-	// ReadOnly type means the agent will only check the existence of the resource based on its metadata.
+	// ReadOnly type means the agent will only check the existence of the resource based on its metadata,
+	// statusFeedBackRules can still be used to get feedbackResults.
 	// +kubebuilder:default=Update
 	// +kubebuilder:validation:Enum=Update;CreateOnly;ServerSideApply;ReadOnly
 	// +kubebuilder:validation:Required

--- a/work/v1/zz_generated.swagger_doc_generated.go
+++ b/work/v1/zz_generated.swagger_doc_generated.go
@@ -287,7 +287,7 @@ func (StatusFeedbackResult) SwaggerDoc() map[string]string {
 
 var map_UpdateStrategy = map[string]string{
 	"":                "UpdateStrategy defines the strategy to update this manifest",
-	"type":            "type defines the strategy to update this manifest, default value is Update. Update type means to update resource by an update call. CreateOnly type means do not update resource based on current manifest. ServerSideApply type means to update resource using server side apply with work-controller as the field manager. If there is conflict, the related Applied condition of manifest will be in the status of False with the reason of ApplyConflict. ReadOnly type means the agent will only check the existence of the resource based on its metadata.",
+	"type":            "type defines the strategy to update this manifest, default value is Update. Update type means to update resource by an update call. CreateOnly type means do not update resource based on current manifest. ServerSideApply type means to update resource using server side apply with work-controller as the field manager. If there is conflict, the related Applied condition of manifest will be in the status of False with the reason of ApplyConflict. ReadOnly type means the agent will only check the existence of the resource based on its metadata, statusFeedBackRules can still be used to get feedbackResults.",
 	"serverSideApply": "serverSideApply defines the configuration for server side apply. It is honored only when type of updateStrategy is ServerSideApply",
 }
 

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -283,7 +283,8 @@ spec:
                                 ServerSideApply type means to update resource using server side apply with work-controller as the field manager.
                                 If there is conflict, the related Applied condition of manifest will be in the status of False with the
                                 reason of ApplyConflict.
-                                ReadOnly type means the agent will only check the existence of the resource based on its metadata.
+                                ReadOnly type means the agent will only check the existence of the resource based on its metadata,
+                                statusFeedBackRules can still be used to get feedbackResults.
                               enum:
                               - Update
                               - CreateOnly


### PR DESCRIPTION
## Summary

I've gotten a question from a developer about `ReadOnly`. It seems like this part of the comment is not too clear because it states it will "only" check the existence but that's not totally true because status feedback can still be used.

## Related issue(s)

Fixes #