### PR TITLE
:bug: add omitempty to RegistrationDriver field

### DIFF
--- a/operator/v1/types_klusterlet.go
+++ b/operator/v1/types_klusterlet.go
@@ -180,9 +180,10 @@ type RegistrationConfiguration struct {
 
 type RegistrationDriver struct {
 	// Type of the authentication used by managedcluster to register as well as pull work from hub. Possible values are csr and awsirsa.
+	// +required
 	// +kubebuilder:default:=csr
 	// +kubebuilder:validation:Enum=csr;awsirsa
-	AuthType string `json:"authType"`
+	AuthType string `json:"authType,omitempty"`
 
 	// Contain the details required for registering with hub cluster (ie: an EKS cluster) using AWS IAM roles for service account.
 	// This is required only when the authType is awsirsa.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Without setting omitempty, reports below error when using client to create cr: 
```
              Message: "Klusterlet.operator.open-cluster-management.io \"klusterlet-multiplehubs-enabled\" is invalid: spec.registrationConfiguration.registrationDriver.authType: Unsupported value: \"\": supported values: \"csr\", \"awsirsa\"",
```
## Related issue(s)

Fixes #