### PR TITLE
:sparkles: Adding hubClusterArn validation in spec

### DIFF
--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -270,7 +270,10 @@ spec:
                           - awsirsa
                           type: string
                         hubClusterArn:
-                          description: This represents the hub cluster ARN
+                          description: |-
+                            This represents the hub cluster ARN
+                            Example - arn:eks:us-west-2:12345678910:cluster/hub-cluster1
+                          pattern: ^arn:aws:eks:([a-zA-Z0-9-]+):(\d{12}):cluster/([a-zA-Z0-9-]+)$
                           type: string
                       type: object
                     type: array

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -126,7 +126,9 @@ type RegistrationDriverHub struct {
 	AuthType string `json:"authType,omitempty"`
 
 	// This represents the hub cluster ARN
+	// Example - arn:eks:us-west-2:12345678910:cluster/hub-cluster1
 	// +optional
+	// +kubebuilder:validation:Pattern=`^arn:aws:eks:([a-zA-Z0-9-]+):(\d{12}):cluster/([a-zA-Z0-9-]+)$`
 	HubClusterArn string `json:"hubClusterArn,omitempty"`
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -124,7 +124,7 @@ func (NodePlacement) SwaggerDoc() map[string]string {
 
 var map_RegistrationDriverHub = map[string]string{
 	"authType":      "Type of the authentication used by hub to initialize the Hub cluster. Possible values are csr and awsirsa.",
-	"hubClusterArn": "This represents the hub cluster ARN",
+	"hubClusterArn": "This represents the hub cluster ARN Example - arn:eks:us-west-2:12345678910:cluster/hub-cluster1",
 }
 
 func (RegistrationDriverHub) SwaggerDoc() map[string]string {

--- a/test/integration/api/clustermanager_test.go
+++ b/test/integration/api/clustermanager_test.go
@@ -261,6 +261,46 @@ var _ = Describe("ClusterManager API test with RegistrationConfiguration", func(
 		Expect(clusterManager.Spec.RegistrationConfiguration.FeatureGates[0].Mode).Should(Equal(operatorv1.FeatureGateModeTypeDisable))
 		Expect(clusterManager.Spec.RegistrationConfiguration.FeatureGates[1].Mode).Should(Equal(operatorv1.FeatureGateModeTypeEnable))
 	})
+
+	It("Create a cluster manager with aws registration and invalid hubClusterArn", func() {
+		clusterManager := &operatorv1.ClusterManager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterManagerName,
+			},
+			Spec: operatorv1.ClusterManagerSpec{
+				RegistrationConfiguration: &operatorv1.RegistrationHubConfiguration{
+					RegistrationDrivers: []operatorv1.RegistrationDriverHub{
+						{
+							AuthType:      "awsirsa",
+							HubClusterArn: "arn:aws:bks:us-west-2:123456789012:cluster/hub-cluster1",
+						},
+					},
+				},
+			},
+		}
+		_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("Create a cluster manager with aws registration and valid hubClusterArn", func() {
+		clusterManager := &operatorv1.ClusterManager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterManagerName,
+			},
+			Spec: operatorv1.ClusterManagerSpec{
+				RegistrationConfiguration: &operatorv1.RegistrationHubConfiguration{
+					RegistrationDrivers: []operatorv1.RegistrationDriverHub{
+						{
+							AuthType:      "awsirsa",
+							HubClusterArn: "arn:aws:eks:us-west-2:123456789012:cluster/hub-cluster1",
+						},
+					},
+				},
+			},
+		}
+		_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+	})
 })
 
 var _ = Describe("ClusterManager API test with WorkConfiguration", func() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Adding validation in spec to avoid adding programmatic validation in clusteradm and ocm

## Related issue(s)

Fixes #https://github.com/open-cluster-management-io/ocm/issues/514