### PR TITLE
🐛 Make hubAcceptsClient optional

### DIFF
--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -154,8 +154,6 @@ spec:
                   - key
                   type: object
                 type: array
-            required:
-            - hubAcceptsClient
             type: object
           status:
             description: Status represents the current status of joined managed cluster

--- a/cluster/v1/types.go
+++ b/cluster/v1/types.go
@@ -59,7 +59,7 @@ type ManagedClusterSpec struct {
 	// the namespace to grant the permision of access from the agent on the managed cluster.
 	// When the value is set to false, the namespace representing the managed cluster is
 	// deleted.
-	// +required
+	// +optional
 	HubAcceptsClient bool `json:"hubAcceptsClient"`
 
 	// LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After upgrade controller gen to 0.16.5, the `managedcluster.spec.hubAcceptsClient` changes to [required](https://github.com/open-cluster-management-io/api/pull/360/files#diff-2a242c670a3f1db23fae6d9b24c75c4056237108616213aee2d5708a3fb17f8cR159), change it back to optional for backwards compatibility

## Related issue(s)

Fixes #