### PR TITLE
:sparkles: add deletionPolicy for manifestWorkReplicaset

### DIFF
--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -61,6 +61,17 @@ spec:
             description: Spec reperesents the desired ManifestWork payload and Placement
               reference to be reconciled
             properties:
+              cascadeDeletionPolicy:
+                default: Background
+                description: |-
+                  CascadeDeletionPolicy decides the manifestWorkReplicaSet is deleted before/after the related manifestWorks are gone.
+                  Acceptable values are:
+                  'Background'- the manifestWorkReplicaSet is deleted without waiting for the related manifestWorks to be gone.
+                  'Foreground'- the manifestWorkReplicaSet is deleted until the related manifestWorks are gone.
+                enum:
+                - Background
+                - Foreground
+                type: string
               manifestWorkTemplate:
                 description: ManifestWorkTemplate is the ManifestWorkSpec that will
                   be used to generate a per-cluster ManifestWork
@@ -581,6 +592,7 @@ spec:
                 minItems: 1
                 type: array
             required:
+            - cascadeDeletionPolicy
             - placementRefs
             type: object
           status:

--- a/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/work/v1alpha1/types_manifestworkreplicaset.go
@@ -63,6 +63,16 @@ type ManifestWorkReplicaSetSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +required
 	PlacementRefs []LocalPlacementReference `json:"placementRefs"`
+
+	// CascadeDeletionPolicy decides the manifestWorkReplicaSet is deleted before/after the related manifestWorks are gone.
+	// Acceptable values are:
+	// 'Background'- the manifestWorkReplicaSet is deleted without waiting for the related manifestWorks to be gone.
+	// 'Foreground'- the manifestWorkReplicaSet is deleted until the related manifestWorks are gone.
+	// +kubebuilder:default=Background
+	// +kubebuilder:validation:Enum=Background;Foreground
+	// +kubebuilder:validation:Required
+	// +optional
+	CascadeDeletionPolicy CascadeDeletionPolicy `json:"cascadeDeletionPolicy,omitempty"`
 }
 
 // ManifestWorkReplicaSetStatus defines the observed state of ManifestWorkReplicaSet
@@ -171,4 +181,15 @@ const (
 	//
 	// Reason: AsExpected, NotAsExpected or Processing
 	ManifestWorkReplicaSetConditionManifestworkApplied string = "ManifestworkApplied"
+)
+
+// CascadeDeletionPolicy decides the manifestWorkReplicaSet is deleted before/after the related manifestWorks are gone.
+type CascadeDeletionPolicy string
+
+const (
+	// Foreground decides the manifestWorkReplicaSet is deleted until the related manifestWorks are gone.
+	Foreground CascadeDeletionPolicy = "Foreground"
+
+	// Background decides the manifestWorkReplicaSet is deleted without waiting for the related manifestWorks to be gone.
+	Background CascadeDeletionPolicy = "Background"
 )

--- a/work/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/work/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -39,9 +39,10 @@ func (ManifestWorkReplicaSetList) SwaggerDoc() map[string]string {
 }
 
 var map_ManifestWorkReplicaSetSpec = map[string]string{
-	"":                     "ManifestWorkReplicaSetSpec defines the desired state of ManifestWorkReplicaSet",
-	"manifestWorkTemplate": "ManifestWorkTemplate is the ManifestWorkSpec that will be used to generate a per-cluster ManifestWork",
-	"placementRefs":        "PacementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used to distribute the ManifestWork.",
+	"":                      "ManifestWorkReplicaSetSpec defines the desired state of ManifestWorkReplicaSet",
+	"manifestWorkTemplate":  "ManifestWorkTemplate is the ManifestWorkSpec that will be used to generate a per-cluster ManifestWork",
+	"placementRefs":         "PacementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used to distribute the ManifestWork.",
+	"cascadeDeletionPolicy": "CascadeDeletionPolicy decides the manifestWorkReplicaSet is deleted before/after the related manifestWorks are gone. Acceptable values are: 'Background'- the manifestWorkReplicaSet is deleted without waiting for the related manifestWorks to be gone. 'Foreground'- the manifestWorkReplicaSet is deleted until the related manifestWorks are gone.",
 }
 
 func (ManifestWorkReplicaSetSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
There is requirement that the manifestWorkReplicaset should be deleted after all related manifestworks are gone. 
So add a filed to configure the deletion policy for the manifestWorkReplicaset. 
Defined 2 deletion policies: Background and Foreground.

## Related issue(s)
https://github.com/open-cluster-management-io/ocm/issues/988
