### PR TITLE
:sparkles: ✨ feature feat: add clusterlabels to klusterlet types.

### DIFF
--- a/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -272,6 +272,12 @@ spec:
                     required:
                     - maxCustomClusterClaims
                     type: object
+                  clusterLabels:
+                    additionalProperties:
+                      type: string
+                    description: ClusterLabels is labels set on ManagedCluster when
+                      creating only, other actors can update it afterwards.
+                    type: object
                   featureGates:
                     description: "FeatureGates represents the list of feature gates
                       for registration\nIf it is set empty, default feature gates

--- a/operator/v1/types_klusterlet.go
+++ b/operator/v1/types_klusterlet.go
@@ -152,6 +152,10 @@ type RegistrationConfiguration struct {
 	// +optional
 	ClusterAnnotations map[string]string `json:"clusterAnnotations,omitempty"`
 
+	// ClusterLabels is labels set on ManagedCluster when creating only, other actors can update it afterwards.
+	// +optional
+	ClusterLabels map[string]string `json:"clusterLabels,omitempty"`
+
 	// KubeAPIQPS indicates the maximum QPS while talking with apiserver on the spoke cluster.
 	// If it is set empty, use the default value: 50
 	// +optional

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -657,6 +657,13 @@ func (in *RegistrationConfiguration) DeepCopyInto(out *RegistrationConfiguration
 			(*out)[key] = val
 		}
 	}
+	if in.ClusterLabels != nil {
+		in, out := &in.ClusterLabels, &out.ClusterLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.BootstrapKubeConfigs.DeepCopyInto(&out.BootstrapKubeConfigs)
 	in.RegistrationDriver.DeepCopyInto(&out.RegistrationDriver)
 	if in.ClusterClaimConfiguration != nil {


### PR DESCRIPTION

## Summary
Add clusterlabels to klusterlet.

## Related issue(s)
#

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional support for setting cluster labels during Klusterlet registration. Labels are applied to a ManagedCluster at creation to aid initial categorization and remain editable afterward; this is backward-compatible and improves attaching metadata during registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->