### PR TITLE
:seedling: add auth type related consts

### DIFF
--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -118,6 +118,25 @@ type RegistrationHubConfiguration struct {
 	RegistrationDrivers []RegistrationDriverHub `json:"registrationDrivers,omitempty"`
 }
 
+const (
+	// AwsIrsaAuthType represents the authentication type that uses AWS IRSA
+	AwsIrsaAuthType = "awsirsa"
+	// CSRAuthType represents the authentication type that uses Kubernetes CSR
+	CSRAuthType = "csr"
+	// GRPCAuthType represents the authentication type that uses gRPC.
+	GRPCAuthType = "grpc"
+)
+
+// GRPCAuthSigner is the signer name used when creating CSRs for gRPC authentication.
+const GRPCAuthSigner = "open-cluster-management.io/grpc"
+
+const (
+	// CSRUsernameAnnotation is added to a CSR to identify the user who requested the CSR.
+	// This should only be honored when registration driver is grpc and the csr user name
+	// is service account of grpc server.
+	CSRUsernameAnnotation = "open-cluster-management.io/csr-user"
+)
+
 type RegistrationDriverHub struct {
 
 	// Type of the authentication used by hub to initialize the Hub cluster. Possible values are csr and awsirsa.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Standardized authentication identifiers: AWS IRSA, CSR, and gRPC for consistent configuration.
  * Added CSR username metadata key to improve traceability of requests.
  * Added gRPC signing metadata and extended registration validation to support gRPC auth, improving reliability of cluster registration flows and future integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->