### PR TITLE
✨ Add CleanUpCompletedManifestwork feature gate

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -88,6 +88,11 @@ const (
 
 	// ClusterImporter will enable the auto import of managed cluster for certain cluster providers, e.g. cluster-api.
 	ClusterImporter featuregate.Feature = "ClusterImporter"
+
+	// CleanUpCompletedManifestWork will delete manifestworks which have Completed status after a specified TTL seconds.
+	// When enabled, the work controller will automatically clean up completed manifest works based on the configured
+	// time-to-live duration to prevent accumulation of old completed resources.
+	CleanUpCompletedManifestWork featuregate.Feature = "CleanUpCompletedManifestWork"
 )
 
 // DefaultSpokeRegistrationFeatureGates consists of all known ocm-registration
@@ -120,9 +125,10 @@ var DefaultHubAddonManagerFeatureGates = map[featuregate.Feature]featuregate.Fea
 // DefaultHubWorkFeatureGates consists of all known acm work wehbook feature keys.
 // To add a new feature, define a key for it above and add it here.
 var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	NilExecutorValidating:  {Default: false, PreRelease: featuregate.Alpha},
-	ManifestWorkReplicaSet: {Default: false, PreRelease: featuregate.Alpha},
-	CloudEventsDrivers:     {Default: false, PreRelease: featuregate.Alpha},
+	NilExecutorValidating:        {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkReplicaSet:       {Default: false, PreRelease: featuregate.Alpha},
+	CloudEventsDrivers:           {Default: false, PreRelease: featuregate.Alpha},
+	CleanUpCompletedManifestWork: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultSpokeWorkFeatureGates consists of all known ocm work feature keys for work agent.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an optional feature flag "CleanUpCompletedManifestWork" (Alpha, disabled by default) to enable automatic cleanup of completed ManifestWorks when enabled.

- Style
  - Minor formatting adjustments to feature gate definitions; no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->