### PR TITLE
🌱 Update godoc of APIs to follow jsonField pattern

### DIFF
--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -148,7 +148,7 @@ spec:
                             The rollout strategy only watches the addon configurations defined in ClusterManagementAddOn.
                           properties:
                             all:
-                              description: All defines required fields for RolloutStrategy
+                              description: all defines required fields for RolloutStrategy
                                 type All
                               properties:
                                 maxFailures:
@@ -195,7 +195,7 @@ spec:
                                   type: string
                               type: object
                             progressive:
-                              description: Progressive defines required fields for
+                              description: progressive defines required fields for
                                 RolloutStrategy type Progressive
                               properties:
                                 mandatoryDecisionGroups:
@@ -211,13 +211,13 @@ spec:
                                     properties:
                                       groupIndex:
                                         description: |-
-                                          GroupIndex of the decision group should match the placementDecisions label value with label key
+                                          groupIndex of the decision group should match the placementDecisions label value with label key
                                           cluster.open-cluster-management.io/decision-group-index
                                         format: int32
                                         type: integer
                                       groupName:
                                         description: |-
-                                          GroupName of the decision group should match the placementDecisions label value with label key
+                                          groupName of the decision group should match the placementDecisions label value with label key
                                           cluster.open-cluster-management.io/decision-group-name
                                         type: string
                                     type: object
@@ -227,7 +227,7 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    MaxConcurrency is the max number of clusters to deploy workload concurrently. The default value
+                                    maxConcurrency is the max number of clusters to deploy workload concurrently. The default value
                                     for MaxConcurrency is determined from the clustersPerDecisionGroup defined in the
                                     placement->DecisionStrategy.
                                   pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
@@ -276,7 +276,7 @@ spec:
                                   type: string
                               type: object
                             progressivePerGroup:
-                              description: ProgressivePerGroup defines required fields
+                              description: progressivePerGroup defines required fields
                                 for RolloutStrategy type ProgressivePerGroup
                               properties:
                                 mandatoryDecisionGroups:
@@ -292,13 +292,13 @@ spec:
                                     properties:
                                       groupIndex:
                                         description: |-
-                                          GroupIndex of the decision group should match the placementDecisions label value with label key
+                                          groupIndex of the decision group should match the placementDecisions label value with label key
                                           cluster.open-cluster-management.io/decision-group-index
                                         format: int32
                                         type: integer
                                       groupName:
                                         description: |-
-                                          GroupName of the decision group should match the placementDecisions label value with label key
+                                          groupName of the decision group should match the placementDecisions label value with label key
                                           cluster.open-cluster-management.io/decision-group-name
                                         type: string
                                     type: object

--- a/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
+++ b/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
@@ -48,7 +48,7 @@ spec:
                 type: string
               customizedVariables:
                 description: |-
-                  CustomizedVariables is a list of name-value variables for the current add-on deployment.
+                  customizedVariables is a list of name-value variables for the current add-on deployment.
                   The add-on implementation can use these variables to render its add-on deployment.
                   The default is an empty list.
                 items:
@@ -73,7 +73,7 @@ spec:
                 x-kubernetes-list-type: map
               nodePlacement:
                 description: |-
-                  NodePlacement enables explicit control over the scheduling of the add-on agents on the
+                  nodePlacement enables explicit control over the scheduling of the add-on agents on the
                   managed cluster.
                   All add-on agent pods are expected to comply with this node placement.
                   If the placement is nil, the placement is not specified, it will be omitted.
@@ -156,7 +156,7 @@ spec:
                 type: object
               registries:
                 description: |-
-                  Registries describes how to override images used by the addon agent on the managed cluster.
+                  registries describes how to override images used by the addon agent on the managed cluster.
                   the following example will override image "quay.io/open-cluster-management/addon-agent" to
                   "quay.io/ocm/addon-agent" when deploying the addon agent
 

--- a/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -50,16 +50,16 @@ spec:
               addon agent resources yaml description.
             properties:
               addonName:
-                description: AddonName represents the name of the addon which the
+                description: addonName represents the name of the addon which the
                   template belongs to
                 type: string
               agentSpec:
-                description: AgentSpec describes what/how the kubernetes resources
+                description: agentSpec describes what/how the kubernetes resources
                   of the addon agent to be deployed on a managed cluster.
                 properties:
                   deleteOption:
                     description: |-
-                      DeleteOption represents deletion strategy when the manifestwork is deleted.
+                      deleteOption represents deletion strategy when the manifestwork is deleted.
                       Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
                     properties:
                       propagationPolicy:
@@ -171,7 +171,7 @@ spec:
                         type: object
                     type: object
                   manifestConfigs:
-                    description: ManifestConfigs represents the configurations of
+                    description: manifestConfigs represents the configurations of
                       manifests defined in workload field.
                     items:
                       description: ManifestConfigOption represents the configurations
@@ -388,11 +388,11 @@ spec:
                       type: object
                     type: array
                   workload:
-                    description: Workload represents the manifest workload to be deployed
+                    description: workload represents the manifest workload to be deployed
                       on a managed cluster.
                     properties:
                       manifests:
-                        description: Manifests represents a list of kuberenetes resources
+                        description: manifests represents a list of kubernetes resources
                           to be deployed on a managed cluster.
                         items:
                           description: Manifest represents a resource to be deployed
@@ -404,7 +404,7 @@ spec:
                     type: object
                 type: object
               registration:
-                description: Registration holds the registration configuration for
+                description: registration holds the registration configuration for
                   the addon
                 items:
                   description: |-

--- a/addon/v1alpha1/types_addondeploymentconfig.go
+++ b/addon/v1alpha1/types_addondeploymentconfig.go
@@ -21,7 +21,7 @@ type AddOnDeploymentConfig struct {
 }
 
 type AddOnDeploymentConfigSpec struct {
-	// CustomizedVariables is a list of name-value variables for the current add-on deployment.
+	// customizedVariables is a list of name-value variables for the current add-on deployment.
 	// The add-on implementation can use these variables to render its add-on deployment.
 	// The default is an empty list.
 	// +optional
@@ -29,7 +29,7 @@ type AddOnDeploymentConfigSpec struct {
 	// +listMapKey=name
 	CustomizedVariables []CustomizedVariable `json:"customizedVariables,omitempty"`
 
-	// NodePlacement enables explicit control over the scheduling of the add-on agents on the
+	// nodePlacement enables explicit control over the scheduling of the add-on agents on the
 	// managed cluster.
 	// All add-on agent pods are expected to comply with this node placement.
 	// If the placement is nil, the placement is not specified, it will be omitted.
@@ -37,7 +37,7 @@ type AddOnDeploymentConfigSpec struct {
 	// +optional
 	NodePlacement *NodePlacement `json:"nodePlacement,omitempty"`
 
-	// Registries describes how to override images used by the addon agent on the managed cluster.
+	// registries describes how to override images used by the addon agent on the managed cluster.
 	// the following example will override image "quay.io/open-cluster-management/addon-agent" to
 	// "quay.io/ocm/addon-agent" when deploying the addon agent
 	//

--- a/addon/v1alpha1/types_addontemplate.go
+++ b/addon/v1alpha1/types_addontemplate.go
@@ -32,17 +32,17 @@ type AddOnTemplate struct {
 
 // AddOnTemplateSpec defines the template of an addon agent which will be deployed on managed clusters.
 type AddOnTemplateSpec struct {
-	// AddonName represents the name of the addon which the template belongs to
+	// addonName represents the name of the addon which the template belongs to
 	// +kubebuilder:validation:Required
 	// +required
 	AddonName string `json:"addonName"`
 
-	// AgentSpec describes what/how the kubernetes resources of the addon agent to be deployed on a managed cluster.
+	// agentSpec describes what/how the kubernetes resources of the addon agent to be deployed on a managed cluster.
 	// +kubebuilder:validation:Required
 	// +required
 	AgentSpec work.ManifestWorkSpec `json:"agentSpec"`
 
-	// Registration holds the registration configuration for the addon
+	// registration holds the registration configuration for the addon
 	// +optional
 	Registration []RegistrationSpec `json:"registration"`
 }

--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -86,7 +86,7 @@ spec:
               leaseDurationSeconds:
                 default: 60
                 description: |-
-                  LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
+                  leaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
                   If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
                 format: int32
                 type: integer
@@ -114,7 +114,7 @@ spec:
                 type: array
               taints:
                 description: |-
-                  Taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
+                  taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
                   Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent
                   running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
                 items:
@@ -124,7 +124,7 @@ spec:
                   properties:
                     effect:
                       description: |-
-                        Effect indicates the effect of the taint on placements that do not tolerate the taint.
+                        effect indicates the effect of the taint on placements that do not tolerate the taint.
                         Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
                       enum:
                       - NoSelect
@@ -133,19 +133,19 @@ spec:
                       type: string
                     key:
                       description: |-
-                        Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
+                        key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
                         The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                     timeAdded:
-                      description: TimeAdded represents the time at which the taint
+                      description: timeAdded represents the time at which the taint
                         was added.
                       format: date-time
                       nullable: true
                       type: string
                     value:
-                      description: Value is the taint value corresponding to the taint
+                      description: value is the taint value corresponding to the taint
                         key.
                       maxLength: 1024
                       type: string
@@ -192,13 +192,13 @@ spec:
                   properties:
                     name:
                       description: |-
-                        Name is the name of a ClusterClaim resource on managed cluster. It's a well known
+                        name is the name of a ClusterClaim resource on managed cluster. It's a well known
                         or customized name to identify the claim.
                       maxLength: 253
                       minLength: 1
                       type: string
                     value:
-                      description: Value is a claim-dependent string
+                      description: value is a claim-dependent string
                       maxLength: 1024
                       minLength: 1
                       type: string
@@ -349,7 +349,7 @@ spec:
                   cluster.
                 properties:
                   kubernetes:
-                    description: Kubernetes is the kubernetes version of managed cluster.
+                    description: kubernetes is the kubernetes version of managed cluster.
                     type: string
                 type: object
             type: object

--- a/cluster/v1/types.go
+++ b/cluster/v1/types.go
@@ -63,13 +63,13 @@ type ManagedClusterSpec struct {
 	// +optional
 	HubAcceptsClient bool `json:"hubAcceptsClient"`
 
-	// LeaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
+	// leaseDurationSeconds is used to coordinate the lease update time of Klusterlet agents on the managed cluster.
 	// If its value is zero, the Klusterlet agent will update its lease every 60 seconds by default
 	// +optional
 	// +kubebuilder:default=60
 	LeaseDurationSeconds int32 `json:"leaseDurationSeconds,omitempty"`
 
-	// Taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
+	// taints is a property of managed cluster that allow the cluster to be repelled when scheduling.
 	// Taints, including 'ManagedClusterUnavailable' and 'ManagedClusterUnreachable', can not be added/removed by agent
 	// running on the managed cluster; while it's fine to add/remove other taints from either hub cluser or managed cluster.
 	// +optional
@@ -92,24 +92,24 @@ type ClientConfig struct {
 // The managed cluster this Taint is attached to has the "effect" on
 // any placement that does not tolerate the Taint.
 type Taint struct {
-	// Key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
+	// key is the taint key applied to a cluster. e.g. bar or foo.example.com/bar.
 	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MaxLength=316
 	// +required
 	Key string `json:"key"`
-	// Value is the taint value corresponding to the taint key.
+	// value is the taint value corresponding to the taint key.
 	// +kubebuilder:validation:MaxLength=1024
 	// +optional
 	Value string `json:"value,omitempty"`
-	// Effect indicates the effect of the taint on placements that do not tolerate the taint.
+	// effect indicates the effect of the taint on placements that do not tolerate the taint.
 	// Valid effects are NoSelect, PreferNoSelect and NoSelectIfNew.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum:=NoSelect;PreferNoSelect;NoSelectIfNew
 	// +required
 	Effect TaintEffect `json:"effect"`
-	// TimeAdded represents the time at which the taint was added.
+	// timeAdded represents the time at which the taint was added.
 	// +nullable
 	// +optional
 	TimeAdded metav1.Time `json:"timeAdded"`
@@ -177,20 +177,20 @@ type ManagedClusterStatus struct {
 // ManagedClusterVersion represents version information about the managed cluster.
 // TODO add managed agent versions
 type ManagedClusterVersion struct {
-	// Kubernetes is the kubernetes version of managed cluster.
+	// kubernetes is the kubernetes version of managed cluster.
 	// +optional
 	Kubernetes string `json:"kubernetes,omitempty"`
 }
 
 // ManagedClusterClaim represents a ClusterClaim collected from a managed cluster.
 type ManagedClusterClaim struct {
-	// Name is the name of a ClusterClaim resource on managed cluster. It's a well known
+	// name is the name of a ClusterClaim resource on managed cluster. It's a well known
 	// or customized name to identify the claim.
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name,omitempty"`
 
-	// Value is a claim-dependent string
+	// value is a claim-dependent string
 	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:MinLength=1
 	Value string `json:"value,omitempty"`

--- a/cluster/v1alpha1/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
+++ b/cluster/v1alpha1/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
@@ -46,7 +46,7 @@ spec:
             description: Spec defines the attributes of the ClusterClaim.
             properties:
               value:
-                description: Value is a claim-dependent string
+                description: value is a claim-dependent string
                 maxLength: 1024
                 minLength: 1
                 type: string

--- a/cluster/v1alpha1/0000_05_clusters.open-cluster-management.io_addonplacementscores.crd.yaml
+++ b/cluster/v1alpha1/0000_05_clusters.open-cluster-management.io_addonplacementscores.crd.yaml
@@ -108,10 +108,10 @@ spec:
                     value.
                   properties:
                     name:
-                      description: Name is the name of the score
+                      description: name is the name of the score
                       type: string
                     value:
-                      description: Value is the value of the score. The score range
+                      description: value is the value of the score. The score range
                         is from -100 to 100.
                       format: int32
                       maximum: 100
@@ -127,7 +127,7 @@ spec:
                 x-kubernetes-list-type: map
               validUntil:
                 description: |-
-                  ValidUntil defines the valid time of the scores.
+                  validUntil defines the valid time of the scores.
                   After this time, the scores are considered to be invalid by placement. nil means never expire.
                   The controller owning this resource should keep the scores up-to-date.
                 format: date-time

--- a/cluster/v1alpha1/types.go
+++ b/cluster/v1alpha1/types.go
@@ -27,7 +27,7 @@ type ClusterClaim struct {
 }
 
 type ClusterClaimSpec struct {
-	// Value is a claim-dependent string
+	// value is a claim-dependent string
 	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:MinLength=1
 	Value string `json:"value,omitempty"`

--- a/cluster/v1alpha1/types_addonplacementscore.go
+++ b/cluster/v1alpha1/types_addonplacementscore.go
@@ -37,7 +37,7 @@ type AddOnPlacementScoreStatus struct {
 	// +optional
 	Scores []AddOnPlacementScoreItem `json:"scores,omitempty"`
 
-	// ValidUntil defines the valid time of the scores.
+	// validUntil defines the valid time of the scores.
 	// After this time, the scores are considered to be invalid by placement. nil means never expire.
 	// The controller owning this resource should keep the scores up-to-date.
 	// +kubebuilder:validation:Type=string
@@ -48,12 +48,12 @@ type AddOnPlacementScoreStatus struct {
 
 // AddOnPlacementScoreItem represents the score name and value.
 type AddOnPlacementScoreItem struct {
-	// Name is the name of the score
+	// name is the name of the score
 	// +kubebuilder:validation:Required
 	// +required
 	Name string `json:"name"`
 
-	// Value is the value of the score. The score range is from -100 to 100.
+	// value is the value of the score. The score range is from -100 to 100.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum:=-100
 	// +kubebuilder:validation:Maximum:=100

--- a/cluster/v1alpha1/types_rolloutstrategy.go
+++ b/cluster/v1alpha1/types_rolloutstrategy.go
@@ -38,15 +38,15 @@ type RolloutStrategy struct {
 	// +optional
 	Type RolloutType `json:"type,omitempty"`
 
-	// All defines required fields for RolloutStrategy type All
+	// all defines required fields for RolloutStrategy type All
 	// +optional
 	All *RolloutAll `json:"all,omitempty"`
 
-	// Progressive defines required fields for RolloutStrategy type Progressive
+	// progressive defines required fields for RolloutStrategy type Progressive
 	// +optional
 	Progressive *RolloutProgressive `json:"progressive,omitempty"`
 
-	// ProgressivePerGroup defines required fields for RolloutStrategy type ProgressivePerGroup
+	// progressivePerGroup defines required fields for RolloutStrategy type ProgressivePerGroup
 	// +optional
 	ProgressivePerGroup *RolloutProgressivePerGroup `json:"progressivePerGroup,omitempty"`
 }
@@ -95,12 +95,12 @@ type RolloutConfig struct {
 // MandatoryDecisionGroup set the decision group name or group index.
 // GroupName is considered first to select the decisionGroups then GroupIndex.
 type MandatoryDecisionGroup struct {
-	// GroupName of the decision group should match the placementDecisions label value with label key
+	// groupName of the decision group should match the placementDecisions label value with label key
 	// cluster.open-cluster-management.io/decision-group-name
 	// +optional
 	GroupName string `json:"groupName,omitempty"`
 
-	// GroupIndex of the decision group should match the placementDecisions label value with label key
+	// groupIndex of the decision group should match the placementDecisions label value with label key
 	// cluster.open-cluster-management.io/decision-group-index
 	// +optional
 	GroupIndex int32 `json:"groupIndex,omitempty"`
@@ -139,7 +139,7 @@ type RolloutProgressive struct {
 	// +optional
 	MandatoryDecisionGroups `json:",inline"`
 
-	// MaxConcurrency is the max number of clusters to deploy workload concurrently. The default value
+	// maxConcurrency is the max number of clusters to deploy workload concurrently. The default value
 	// for MaxConcurrency is determined from the clustersPerDecisionGroup defined in the
 	// placement->DecisionStrategy.
 	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"

--- a/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
@@ -72,7 +72,7 @@ spec:
             properties:
               clusterSets:
                 description: |-
-                  ClusterSets represent the ManagedClusterSets from which the ManagedClusters are selected.
+                  clusterSets represent the ManagedClusterSets from which the ManagedClusters are selected.
                   If the slice is empty, ManagedClusters will be selected from the ManagedClusterSets bound to the placement
                   namespace, otherwise ManagedClusters will be selected from the intersection of this slice and the
                   ManagedClusterSets bound to the placement namespace.
@@ -80,12 +80,12 @@ spec:
                   type: string
                 type: array
               decisionStrategy:
-                description: DecisionStrategy divide the created placement decision
-                  to groups and define number of clusters per decision group.
+                description: decisionStrategy divides the created placement decisions
+                  into groups and defines the number of clusters per decision group.
                 properties:
                   groupStrategy:
-                    description: GroupStrategy define strategies to divide selected
-                      clusters to decision groups.
+                    description: groupStrategy defines strategies to divide selected
+                      clusters into decision groups.
                     properties:
                       clustersPerDecisionGroup:
                         anyOf:
@@ -93,7 +93,7 @@ spec:
                         - type: string
                         default: 100%
                         description: |-
-                          ClustersPerDecisionGroup is a specific number or percentage of the total selected clusters.
+                          clustersPerDecisionGroup is a specific number or percentage of the total selected clusters.
                           The specific number will divide the placementDecisions to decisionGroups each group has max number of clusters
                           equal to that specific number.
                           The percentage will divide the placementDecisions to decisionGroups each group has max number of clusters based
@@ -109,7 +109,7 @@ spec:
                         x-kubernetes-int-or-string: true
                       decisionGroups:
                         description: |-
-                          DecisionGroups represents a list of predefined groups to put decision results.
+                          decisionGroups represents a list of predefined groups to put decision results.
                           Decision groups will be constructed based on the DecisionGroups field at first. The clusters not included in the
                           DecisionGroups will be divided to other decision groups afterwards. Each decision group should not have the number
                           of clusters larger than the ClustersPerDecisionGroup.
@@ -118,11 +118,11 @@ spec:
                             will be added to placementDecisions with groupName label.
                           properties:
                             groupClusterSelector:
-                              description: LabelSelector to select clusters subset
-                                by label.
+                              description: groupClusterSelector selects a subset of
+                                clusters by labels.
                               properties:
                                 claimSelector:
-                                  description: ClaimSelector represents a selector
+                                  description: claimSelector represents a selector
                                     of ManagedClusters by clusterClaims in status
                                   properties:
                                     matchExpressions:
@@ -160,7 +160,7 @@ spec:
                                       type: array
                                   type: object
                                 labelSelector:
-                                  description: LabelSelector represents a selector
+                                  description: labelSelector represents a selector
                                     of ManagedClusters by label
                                   properties:
                                     matchExpressions:
@@ -209,9 +209,9 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             groupName:
-                              description: Group name to be added as label value to
-                                the created placement Decisions labels with label
-                                key cluster.open-cluster-management.io/decision-group-name
+                              description: |-
+                                groupName to set as the label value on created PlacementDecision
+                                resources using the label key cluster.open-cluster-management.io/decision-group-name.
                               pattern: ^[a-zA-Z0-9][-A-Za-z0-9_.]{0,61}[a-zA-Z0-9]$
                               type: string
                           required:
@@ -223,7 +223,7 @@ spec:
                 type: object
               numberOfClusters:
                 description: |-
-                  NumberOfClusters represents the desired number of ManagedClusters to be selected which meet the
+                  numberOfClusters represents the desired number of ManagedClusters to be selected which meet the
                   placement requirements.
                   1) If not specified, all ManagedClusters which meet the placement requirements (including ClusterSets,
                      and Predicates) will be selected;
@@ -237,14 +237,14 @@ spec:
                 format: int32
                 type: integer
               predicates:
-                description: Predicates represent a slice of predicates to select
+                description: predicates represent a slice of predicates to select
                   ManagedClusters. The predicates are ORed.
                 items:
                   description: ClusterPredicate represents a predicate to select ManagedClusters.
                   properties:
                     requiredClusterSelector:
                       description: |-
-                        RequiredClusterSelector represents a selector of ManagedClusters by label and claim. If specified,
+                        requiredClusterSelector represents a selector of ManagedClusters by label and claim. If specified,
                         1) Any ManagedCluster, which does not match the selector, should not be selected by this ClusterPredicate;
                         2) If a selected ManagedCluster (of this ClusterPredicate) ceases to match the selector (e.g. due to
                            an update) of any ClusterPredicate, it will be eventually removed from the placement decisions;
@@ -252,7 +252,7 @@ spec:
                            be selected or at least has a chance to be selected (when NumberOfClusters is specified);
                       properties:
                         celSelector:
-                          description: CelSelector represents a selector of ManagedClusters
+                          description: celSelector represents a selector of ManagedClusters
                             by CEL expressions on ManagedCluster fields
                           properties:
                             celExpressions:
@@ -261,7 +261,7 @@ spec:
                               type: array
                           type: object
                         claimSelector:
-                          description: ClaimSelector represents a selector of ManagedClusters
+                          description: claimSelector represents a selector of ManagedClusters
                             by clusterClaims in status
                           properties:
                             matchExpressions:
@@ -298,7 +298,7 @@ spec:
                               type: array
                           type: object
                         labelSelector:
-                          description: LabelSelector represents a selector of ManagedClusters
+                          description: labelSelector represents a selector of ManagedClusters
                             by label
                           properties:
                             matchExpressions:
@@ -349,7 +349,7 @@ spec:
                 type: array
               prioritizerPolicy:
                 description: |-
-                  PrioritizerPolicy defines the policy of the prioritizers.
+                  prioritizerPolicy defines the policy of the prioritizers.
                   If this field is unset, then default prioritizer mode and configurations are used.
                   Referring to PrioritizerPolicy to see more description about Mode and Configurations.
                 properties:
@@ -359,7 +359,7 @@ spec:
                         of prioritizer
                       properties:
                         scoreCoordinate:
-                          description: ScoreCoordinate represents the configuration
+                          description: scoreCoordinate represents the configuration
                             of the prioritizer and score source.
                           properties:
                             addOn:
@@ -368,13 +368,13 @@ spec:
                               properties:
                                 resourceName:
                                   description: |-
-                                    ResourceName defines the resource name of the AddOnPlacementScore.
+                                    resourceName defines the resource name of the AddOnPlacementScore.
                                     The placement prioritizer selects AddOnPlacementScore CR by this name.
                                   type: string
                                 scoreName:
                                   description: |-
-                                    ScoreName defines the score name inside AddOnPlacementScore.
-                                    AddOnPlacementScore contains a list of score name and score value, ScoreName specify the score to be used by
+                                    scoreName defines the score name inside AddOnPlacementScore.
+                                    AddOnPlacementScore contains a list of score names and values; scoreName specifies the score to be used by
                                     the prioritizer.
                                   type: string
                               required:
@@ -392,7 +392,7 @@ spec:
                             type:
                               default: BuiltIn
                               description: |-
-                                Type defines the type of the prioritizer score.
+                                type defines the type of the prioritizer score.
                                 Type is either "BuiltIn", "AddOn" or "", where "" is "BuiltIn" by default.
                                 When the type is "BuiltIn", need to specify a BuiltIn prioritizer name in BuiltIn.
                                 When the type is "AddOn", need to configure the score source in AddOn.
@@ -406,7 +406,7 @@ spec:
                         weight:
                           default: 1
                           description: |-
-                            Weight defines the weight of the prioritizer score. The value must be ranged in [-10,10].
+                            weight defines the weight of the prioritizer score. The value must be ranged in [-10,10].
                             Each prioritizer will calculate an integer score of a cluster in the range of [-100, 100].
                             The final score of a cluster will be sum(weight * prioritizer_score).
                             A higher weight indicates that the prioritizer weights more in the cluster selection,
@@ -434,7 +434,7 @@ spec:
                 type: object
               spreadPolicy:
                 description: |-
-                  SpreadPolicy defines how placement decisions should be distributed among a
+                  spreadPolicy defines how placement decisions should be distributed among a
                   set of ManagedClusters.
                 properties:
                   spreadConstraints:
@@ -490,7 +490,7 @@ spec:
                 type: object
               tolerations:
                 description: |-
-                  Tolerations are applied to placements, and allow (but do not require) the managed clusters with
+                  tolerations are applied to placements, and allow (but do not require) the managed clusters with
                   certain taints to be selected by placements with matching tolerations.
                 items:
                   description: |-
@@ -634,7 +634,7 @@ spec:
                   type: object
                 type: array
               numberOfSelectedClusters:
-                description: NumberOfSelectedClusters represents the number of selected
+                description: numberOfSelectedClusters represents the number of selected
                   ManagedClusters
                 format: int32
                 type: integer

--- a/cluster/v1beta1/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml
+++ b/cluster/v1beta1/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml
@@ -48,7 +48,7 @@ spec:
             properties:
               decisions:
                 description: |-
-                  Decisions is a slice of decisions according to a placement
+                  decisions is a slice of decisions according to a placement
                   The number of decisions should not be larger than 100
                 items:
                   description: |-
@@ -57,11 +57,11 @@ spec:
                   properties:
                     clusterName:
                       description: |-
-                        ClusterName is the name of the ManagedCluster. If it is not empty, its value should be unique cross all
+                        clusterName is the name of the ManagedCluster. If it is not empty, its value should be unique across all
                         placement decisions for the Placement.
                       type: string
                     reason:
-                      description: Reason represents the reason why the ManagedCluster
+                      description: reason represents the reason why the ManagedCluster
                         is selected.
                       type: string
                   required:

--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -56,14 +56,14 @@ type Placement struct {
 // An empty PlacementSpec selects all ManagedClusters from the ManagedClusterSets bound to
 // the placement namespace. The containing fields are ANDed.
 type PlacementSpec struct {
-	// ClusterSets represent the ManagedClusterSets from which the ManagedClusters are selected.
+	// clusterSets represent the ManagedClusterSets from which the ManagedClusters are selected.
 	// If the slice is empty, ManagedClusters will be selected from the ManagedClusterSets bound to the placement
 	// namespace, otherwise ManagedClusters will be selected from the intersection of this slice and the
 	// ManagedClusterSets bound to the placement namespace.
 	// +optional
 	ClusterSets []string `json:"clusterSets,omitempty"`
 
-	// NumberOfClusters represents the desired number of ManagedClusters to be selected which meet the
+	// numberOfClusters represents the desired number of ManagedClusters to be selected which meet the
 	// placement requirements.
 	// 1) If not specified, all ManagedClusters which meet the placement requirements (including ClusterSets,
 	//    and Predicates) will be selected;
@@ -77,40 +77,41 @@ type PlacementSpec struct {
 	// +optional
 	NumberOfClusters *int32 `json:"numberOfClusters,omitempty"`
 
-	// Predicates represent a slice of predicates to select ManagedClusters. The predicates are ORed.
+	// predicates represent a slice of predicates to select ManagedClusters. The predicates are ORed.
 	// +optional
 	Predicates []ClusterPredicate `json:"predicates,omitempty"`
 
-	// PrioritizerPolicy defines the policy of the prioritizers.
+	// prioritizerPolicy defines the policy of the prioritizers.
 	// If this field is unset, then default prioritizer mode and configurations are used.
 	// Referring to PrioritizerPolicy to see more description about Mode and Configurations.
 	// +optional
 	PrioritizerPolicy PrioritizerPolicy `json:"prioritizerPolicy"`
 
-	// SpreadPolicy defines how placement decisions should be distributed among a
+	// spreadPolicy defines how placement decisions should be distributed among a
 	// set of ManagedClusters.
 	// +optional
 	SpreadPolicy SpreadPolicy `json:"spreadPolicy,omitempty"`
 
-	// Tolerations are applied to placements, and allow (but do not require) the managed clusters with
+	// tolerations are applied to placements, and allow (but do not require) the managed clusters with
 	// certain taints to be selected by placements with matching tolerations.
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty"`
 
-	// DecisionStrategy divide the created placement decision to groups and define number of clusters per decision group.
+	// decisionStrategy divides the created placement decisions into groups and defines the number of clusters per decision group.
 	// +optional
 	DecisionStrategy DecisionStrategy `json:"decisionStrategy,omitempty"`
 }
 
 // DecisionGroup define a subset of clusters that will be added to placementDecisions with groupName label.
 type DecisionGroup struct {
-	// Group name to be added as label value to the created placement Decisions labels with label key cluster.open-cluster-management.io/decision-group-name
+	// groupName to set as the label value on created PlacementDecision
+	// resources using the label key cluster.open-cluster-management.io/decision-group-name.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z0-9][-A-Za-z0-9_.]{0,61}[a-zA-Z0-9]$"
 	// +required
 	GroupName string `json:"groupName,omitempty"`
 
-	// LabelSelector to select clusters subset by label.
+	// groupClusterSelector selects a subset of clusters by labels.
 	// +kubebuilder:validation:Required
 	// +required
 	ClusterSelector GroupClusterSelector `json:"groupClusterSelector,omitempty"`
@@ -119,25 +120,25 @@ type DecisionGroup struct {
 // GroupClusterSelector represents the AND of the containing selectors for groupClusterSelector. An empty group cluster selector matches all objects.
 // A null group cluster selector matches no objects.
 type GroupClusterSelector struct {
-	// LabelSelector represents a selector of ManagedClusters by label
+	// labelSelector represents a selector of ManagedClusters by label
 	// +optional
 	LabelSelector metav1.LabelSelector `json:"labelSelector,omitempty"`
 
-	// ClaimSelector represents a selector of ManagedClusters by clusterClaims in status
+	// claimSelector represents a selector of ManagedClusters by clusterClaims in status
 	// +optional
 	ClaimSelector ClusterClaimSelector `json:"claimSelector,omitempty"`
 }
 
 // Group the created placementDecision into decision groups based on the number of clusters per decision group.
 type GroupStrategy struct {
-	// DecisionGroups represents a list of predefined groups to put decision results.
+	// decisionGroups represents a list of predefined groups to put decision results.
 	// Decision groups will be constructed based on the DecisionGroups field at first. The clusters not included in the
 	// DecisionGroups will be divided to other decision groups afterwards. Each decision group should not have the number
 	// of clusters larger than the ClustersPerDecisionGroup.
 	// +optional
 	DecisionGroups []DecisionGroup `json:"decisionGroups,omitempty"`
 
-	// ClustersPerDecisionGroup is a specific number or percentage of the total selected clusters.
+	// clustersPerDecisionGroup is a specific number or percentage of the total selected clusters.
 	// The specific number will divide the placementDecisions to decisionGroups each group has max number of clusters
 	// equal to that specific number.
 	// The percentage will divide the placementDecisions to decisionGroups each group has max number of clusters based
@@ -159,14 +160,14 @@ type GroupStrategy struct {
 
 // DecisionStrategy divide the created placement decision to groups and define number of clusters per decision group.
 type DecisionStrategy struct {
-	// GroupStrategy define strategies to divide selected clusters to decision groups.
+	// groupStrategy defines strategies to divide selected clusters into decision groups.
 	// +optional
 	GroupStrategy GroupStrategy `json:"groupStrategy,omitempty"`
 }
 
 // ClusterPredicate represents a predicate to select ManagedClusters.
 type ClusterPredicate struct {
-	// RequiredClusterSelector represents a selector of ManagedClusters by label and claim. If specified,
+	// requiredClusterSelector represents a selector of ManagedClusters by label and claim. If specified,
 	// 1) Any ManagedCluster, which does not match the selector, should not be selected by this ClusterPredicate;
 	// 2) If a selected ManagedCluster (of this ClusterPredicate) ceases to match the selector (e.g. due to
 	//    an update) of any ClusterPredicate, it will be eventually removed from the placement decisions;
@@ -179,15 +180,15 @@ type ClusterPredicate struct {
 // ClusterSelector represents the AND of the containing selectors. An empty cluster selector matches all objects.
 // A null cluster selector matches no objects.
 type ClusterSelector struct {
-	// LabelSelector represents a selector of ManagedClusters by label
+	// labelSelector represents a selector of ManagedClusters by label
 	// +optional
 	LabelSelector metav1.LabelSelector `json:"labelSelector,omitempty"`
 
-	// ClaimSelector represents a selector of ManagedClusters by clusterClaims in status
+	// claimSelector represents a selector of ManagedClusters by clusterClaims in status
 	// +optional
 	ClaimSelector ClusterClaimSelector `json:"claimSelector,omitempty"`
 
-	// CelSelector represents a selector of ManagedClusters by CEL expressions on ManagedCluster fields
+	// celSelector represents a selector of ManagedClusters by CEL expressions on ManagedCluster fields
 	// +optional
 	CelSelector ClusterCelSelector `json:"celSelector,omitempty"`
 }
@@ -234,12 +235,12 @@ const (
 
 // PrioritizerConfig represents the configuration of prioritizer
 type PrioritizerConfig struct {
-	// ScoreCoordinate represents the configuration of the prioritizer and score source.
+	// scoreCoordinate represents the configuration of the prioritizer and score source.
 	// +kubebuilder:validation:Required
 	// +required
 	ScoreCoordinate *ScoreCoordinate `json:"scoreCoordinate,omitempty"`
 
-	// Weight defines the weight of the prioritizer score. The value must be ranged in [-10,10].
+	// weight defines the weight of the prioritizer score. The value must be ranged in [-10,10].
 	// Each prioritizer will calculate an integer score of a cluster in the range of [-100, 100].
 	// The final score of a cluster will be sum(weight * prioritizer_score).
 	// A higher weight indicates that the prioritizer weights more in the cluster selection,
@@ -254,7 +255,7 @@ type PrioritizerConfig struct {
 
 // ScoreCoordinate represents the configuration of the score type and score source
 type ScoreCoordinate struct {
-	// Type defines the type of the prioritizer score.
+	// type defines the type of the prioritizer score.
 	// Type is either "BuiltIn", "AddOn" or "", where "" is "BuiltIn" by default.
 	// When the type is "BuiltIn", need to specify a BuiltIn prioritizer name in BuiltIn.
 	// When the type is "AddOn", need to configure the score source in AddOn.
@@ -285,14 +286,14 @@ const (
 
 // AddOnScore represents the configuration of the addon score source.
 type AddOnScore struct {
-	// ResourceName defines the resource name of the AddOnPlacementScore.
+	// resourceName defines the resource name of the AddOnPlacementScore.
 	// The placement prioritizer selects AddOnPlacementScore CR by this name.
 	// +kubebuilder:validation:Required
 	// +required
 	ResourceName string `json:"resourceName"`
 
-	// ScoreName defines the score name inside AddOnPlacementScore.
-	// AddOnPlacementScore contains a list of score name and score value, ScoreName specify the score to be used by
+	// scoreName defines the score name inside AddOnPlacementScore.
+	// AddOnPlacementScore contains a list of score names and values; scoreName specifies the score to be used by
 	// the prioritizer.
 	// +kubebuilder:validation:Required
 	// +required
@@ -428,7 +429,7 @@ type DecisionGroupStatus struct {
 }
 
 type PlacementStatus struct {
-	// NumberOfSelectedClusters represents the number of selected ManagedClusters
+	// numberOfSelectedClusters represents the number of selected ManagedClusters
 	// +optional
 	NumberOfSelectedClusters int32 `json:"numberOfSelectedClusters"`
 

--- a/cluster/v1beta1/types_placementdecision.go
+++ b/cluster/v1beta1/types_placementdecision.go
@@ -38,7 +38,7 @@ const (
 
 // PlacementDecisionStatus represents the current status of the PlacementDecision.
 type PlacementDecisionStatus struct {
-	// Decisions is a slice of decisions according to a placement
+	// decisions is a slice of decisions according to a placement
 	// The number of decisions should not be larger than 100
 	// +kubebuilder:validation:Required
 	// +required
@@ -48,13 +48,13 @@ type PlacementDecisionStatus struct {
 // ClusterDecision represents a decision from a placement
 // An empty ClusterDecision indicates it is not scheduled yet.
 type ClusterDecision struct {
-	// ClusterName is the name of the ManagedCluster. If it is not empty, its value should be unique cross all
+	// clusterName is the name of the ManagedCluster. If it is not empty, its value should be unique across all
 	// placement decisions for the Placement.
 	// +kubebuilder:validation:Required
 	// +required
 	ClusterName string `json:"clusterName"`
 
-	// Reason represents the reason why the ManagedCluster is selected.
+	// reason represents the reason why the ManagedCluster is selected.
 	// +kubebuilder:validation:Required
 	// +required
 	Reason string `json:"reason"`

--- a/cluster/v1beta2/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/cluster/v1beta2/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -65,10 +65,10 @@ spec:
               clusterSelector:
                 default:
                   selectorType: ExclusiveClusterSetLabel
-                description: ClusterSelector represents a selector of ManagedClusters
+                description: clusterSelector represents a selector of ManagedClusters
                 properties:
                   labelSelector:
-                    description: LabelSelector define the general labelSelector which
+                    description: labelSelector define the general labelSelector which
                       clusterset will use to select target managedClusters
                     properties:
                       matchExpressions:
@@ -117,7 +117,7 @@ spec:
                   selectorType:
                     default: ExclusiveClusterSetLabel
                     description: |-
-                      SelectorType could only be "ExclusiveClusterSetLabel" or "LabelSelector"
+                      selectorType could only be "ExclusiveClusterSetLabel" or "LabelSelector"
                       "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
                       "LabelSelector" means use labelSelector to select target managedClusters
                     enum:

--- a/cluster/v1beta2/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/cluster/v1beta2/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -47,7 +47,7 @@ spec:
             properties:
               clusterSet:
                 description: |-
-                  ClusterSet is the name of the ManagedClusterSet to bind. It must match the
+                  clusterSet is the name of the ManagedClusterSet to bind. It must match the
                   instance name of the ManagedClusterSetBinding and cannot change once created.
                   User is allowed to set this field if they have an RBAC rule to CREATE on the
                   virtual subresource of managedclustersets/bind.

--- a/cluster/v1beta2/types_managedclusterset.go
+++ b/cluster/v1beta2/types_managedclusterset.go
@@ -45,7 +45,7 @@ type ManagedClusterSet struct {
 
 // ManagedClusterSetSpec describes the attributes of the ManagedClusterSet
 type ManagedClusterSetSpec struct {
-	// ClusterSelector represents a selector of ManagedClusters
+	// clusterSelector represents a selector of ManagedClusters
 	// +optional
 	// +kubebuilder:default:={selectorType: ExclusiveClusterSetLabel}
 	ClusterSelector ManagedClusterSelector `json:"clusterSelector,omitempty"`
@@ -60,7 +60,7 @@ type ManagedClusterSetSpec struct {
 
 // ManagedClusterSelector represents a selector of ManagedClusters
 type ManagedClusterSelector struct {
-	// SelectorType could only be "ExclusiveClusterSetLabel" or "LabelSelector"
+	// selectorType could only be "ExclusiveClusterSetLabel" or "LabelSelector"
 	// "ExclusiveClusterSetLabel" means to use label "cluster.open-cluster-management.io/clusterset:<ManagedClusterSet Name>"" to select target clusters.
 	// "LabelSelector" means use labelSelector to select target managedClusters
 	// +kubebuilder:validation:Enum=ExclusiveClusterSetLabel;LabelSelector
@@ -68,7 +68,7 @@ type ManagedClusterSelector struct {
 	// +required
 	SelectorType SelectorType `json:"selectorType,omitempty"`
 
-	// LabelSelector define the general labelSelector which clusterset will use to select target managedClusters
+	// labelSelector define the general labelSelector which clusterset will use to select target managedClusters
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 }

--- a/cluster/v1beta2/types_managedclustersetbinding.go
+++ b/cluster/v1beta2/types_managedclustersetbinding.go
@@ -30,7 +30,7 @@ type ManagedClusterSetBinding struct {
 
 // ManagedClusterSetBindingSpec defines the attributes of ManagedClusterSetBinding.
 type ManagedClusterSetBindingSpec struct {
-	// ClusterSet is the name of the ManagedClusterSet to bind. It must match the
+	// clusterSet is the name of the ManagedClusterSet to bind. It must match the
 	// instance name of the ManagedClusterSetBinding and cannot change once created.
 	// User is allowed to set this field if they have an RBAC rule to CREATE on the
 	// virtual subresource of managedclustersets/bind.

--- a/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -45,7 +45,7 @@ spec:
             properties:
               clusterName:
                 description: |-
-                  ClusterName is the name of the managed cluster to be created on hub.
+                  clusterName is the name of the managed cluster to be created on hub.
                   The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
                 maxLength: 63
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -112,7 +112,7 @@ spec:
                 type: string
               namespace:
                 description: |-
-                  Namespace is the namespace to deploy the agent on the managed cluster.
+                  namespace is the namespace to deploy the agent on the managed cluster.
                   The namespace must have a prefix of "open-cluster-management-", and if it is not set,
                   the namespace of "open-cluster-management-agent" is used to deploy agent.
                   In addition, the add-ons are deployed to the namespace of "{Namespace}-addon".

--- a/operator/v1/types_klusterlet.go
+++ b/operator/v1/types_klusterlet.go
@@ -29,7 +29,7 @@ type Klusterlet struct {
 
 // KlusterletSpec represents the desired deployment configuration of Klusterlet agent.
 type KlusterletSpec struct {
-	// Namespace is the namespace to deploy the agent on the managed cluster.
+	// namespace is the namespace to deploy the agent on the managed cluster.
 	// The namespace must have a prefix of "open-cluster-management-", and if it is not set,
 	// the namespace of "open-cluster-management-agent" is used to deploy agent.
 	// In addition, the add-ons are deployed to the namespace of "{Namespace}-addon".
@@ -57,7 +57,7 @@ type KlusterletSpec struct {
 	// +optional
 	ImagePullSpec string `json:"imagePullSpec,omitempty"`
 
-	// ClusterName is the name of the managed cluster to be created on hub.
+	// clusterName is the name of the managed cluster to be created on hub.
 	// The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
 	// +optional
 	// +kubebuilder:validation:MaxLength=63

--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -45,7 +45,7 @@ spec:
             properties:
               deleteOption:
                 description: |-
-                  DeleteOption represents deletion strategy when the manifestwork is deleted.
+                  deleteOption represents deletion strategy when the manifestwork is deleted.
                   Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
                 properties:
                   propagationPolicy:
@@ -156,7 +156,7 @@ spec:
                     type: object
                 type: object
               manifestConfigs:
-                description: ManifestConfigs represents the configurations of manifests
+                description: manifestConfigs represents the configurations of manifests
                   defined in workload field.
                 items:
                   description: ManifestConfigOption represents the configurations
@@ -371,11 +371,11 @@ spec:
                   type: object
                 type: array
               workload:
-                description: Workload represents the manifest workload to be deployed
+                description: workload represents the manifest workload to be deployed
                   on a managed cluster.
                 properties:
                   manifests:
-                    description: Manifests represents a list of kuberenetes resources
+                    description: manifests represents a list of kubernetes resources
                       to be deployed on a managed cluster.
                     items:
                       description: Manifest represents a resource to be deployed on

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -35,15 +35,15 @@ const (
 
 // ManifestWorkSpec represents a desired configuration of manifests to be deployed on the managed cluster.
 type ManifestWorkSpec struct {
-	// Workload represents the manifest workload to be deployed on a managed cluster.
+	// workload represents the manifest workload to be deployed on a managed cluster.
 	Workload ManifestsTemplate `json:"workload,omitempty"`
 
-	// DeleteOption represents deletion strategy when the manifestwork is deleted.
+	// deleteOption represents deletion strategy when the manifestwork is deleted.
 	// Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
 	// +optional
 	DeleteOption *DeleteOption `json:"deleteOption,omitempty"`
 
-	// ManifestConfigs represents the configurations of manifests defined in workload field.
+	// manifestConfigs represents the configurations of manifests defined in workload field.
 	// +optional
 	ManifestConfigs []ManifestConfigOption `json:"manifestConfigs,omitempty"`
 
@@ -65,7 +65,7 @@ type Manifest struct {
 
 // ManifestsTemplate represents the manifest workload to be deployed on a managed cluster.
 type ManifestsTemplate struct {
-	// Manifests represents a list of kuberenetes resources to be deployed on a managed cluster.
+	// manifests represents a list of kubernetes resources to be deployed on a managed cluster.
 	// +optional
 	Manifests []Manifest `json:"manifests,omitempty"`
 }

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -73,12 +73,12 @@ spec:
                 - Foreground
                 type: string
               manifestWorkTemplate:
-                description: ManifestWorkTemplate is the ManifestWorkSpec that will
+                description: manifestWorkTemplate is the ManifestWorkSpec that will
                   be used to generate a per-cluster ManifestWork
                 properties:
                   deleteOption:
                     description: |-
-                      DeleteOption represents deletion strategy when the manifestwork is deleted.
+                      deleteOption represents deletion strategy when the manifestwork is deleted.
                       Foreground deletion strategy is applied to all the resource in this manifestwork if it is not set.
                     properties:
                       propagationPolicy:
@@ -190,7 +190,7 @@ spec:
                         type: object
                     type: object
                   manifestConfigs:
-                    description: ManifestConfigs represents the configurations of
+                    description: manifestConfigs represents the configurations of
                       manifests defined in workload field.
                     items:
                       description: ManifestConfigOption represents the configurations
@@ -407,11 +407,11 @@ spec:
                       type: object
                     type: array
                   workload:
-                    description: Workload represents the manifest workload to be deployed
+                    description: workload represents the manifest workload to be deployed
                       on a managed cluster.
                     properties:
                       manifests:
-                        description: Manifests represents a list of kuberenetes resources
+                        description: manifests represents a list of kubernetes resources
                           to be deployed on a managed cluster.
                         items:
                           description: Manifest represents a resource to be deployed
@@ -424,7 +424,7 @@ spec:
                 type: object
               placementRefs:
                 description: |-
-                  PacementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used
+                  placementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used
                   to distribute the ManifestWork.
                 items:
                   description: localPlacementReference is the name of a Placement
@@ -443,7 +443,7 @@ spec:
                         clusters by Placement and DecisionStrategy.
                       properties:
                         all:
-                          description: All defines required fields for RolloutStrategy
+                          description: all defines required fields for RolloutStrategy
                             type All
                           properties:
                             maxFailures:
@@ -490,7 +490,7 @@ spec:
                               type: string
                           type: object
                         progressive:
-                          description: Progressive defines required fields for RolloutStrategy
+                          description: progressive defines required fields for RolloutStrategy
                             type Progressive
                           properties:
                             mandatoryDecisionGroups:
@@ -506,13 +506,13 @@ spec:
                                 properties:
                                   groupIndex:
                                     description: |-
-                                      GroupIndex of the decision group should match the placementDecisions label value with label key
+                                      groupIndex of the decision group should match the placementDecisions label value with label key
                                       cluster.open-cluster-management.io/decision-group-index
                                     format: int32
                                     type: integer
                                   groupName:
                                     description: |-
-                                      GroupName of the decision group should match the placementDecisions label value with label key
+                                      groupName of the decision group should match the placementDecisions label value with label key
                                       cluster.open-cluster-management.io/decision-group-name
                                     type: string
                                 type: object
@@ -522,7 +522,7 @@ spec:
                               - type: integer
                               - type: string
                               description: |-
-                                MaxConcurrency is the max number of clusters to deploy workload concurrently. The default value
+                                maxConcurrency is the max number of clusters to deploy workload concurrently. The default value
                                 for MaxConcurrency is determined from the clustersPerDecisionGroup defined in the
                                 placement->DecisionStrategy.
                               pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
@@ -571,7 +571,7 @@ spec:
                               type: string
                           type: object
                         progressivePerGroup:
-                          description: ProgressivePerGroup defines required fields
+                          description: progressivePerGroup defines required fields
                             for RolloutStrategy type ProgressivePerGroup
                           properties:
                             mandatoryDecisionGroups:
@@ -587,13 +587,13 @@ spec:
                                 properties:
                                   groupIndex:
                                     description: |-
-                                      GroupIndex of the decision group should match the placementDecisions label value with label key
+                                      groupIndex of the decision group should match the placementDecisions label value with label key
                                       cluster.open-cluster-management.io/decision-group-index
                                     format: int32
                                     type: integer
                                   groupName:
                                     description: |-
-                                      GroupName of the decision group should match the placementDecisions label value with label key
+                                      groupName of the decision group should match the placementDecisions label value with label key
                                       cluster.open-cluster-management.io/decision-group-name
                                     type: string
                                 type: object

--- a/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/work/v1alpha1/types_manifestworkreplicaset.go
@@ -55,10 +55,10 @@ type ManifestWorkReplicaSet struct {
 
 // ManifestWorkReplicaSetSpec defines the desired state of ManifestWorkReplicaSet
 type ManifestWorkReplicaSetSpec struct {
-	// ManifestWorkTemplate is the ManifestWorkSpec that will be used to generate a per-cluster ManifestWork
+	// manifestWorkTemplate is the ManifestWorkSpec that will be used to generate a per-cluster ManifestWork
 	ManifestWorkTemplate work.ManifestWorkSpec `json:"manifestWorkTemplate"`
 
-	// PacementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used
+	// placementRefs is a list of the names of the Placement resource, from which a PlacementDecision will be found and used
 	// to distribute the ManifestWork.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Clarified clustersPerDecisionGroup supports integer or percentage strings (e.g., "20%"); default remains 100%.

- Documentation
  - Standardized CRD field descriptions to start with lowercase across add-on, cluster, operator, and work APIs.
  - Expanded guidance and examples for clustersPerDecisionGroup behavior.
  - Fixed typo in placementRefs and harmonized rollout strategy and decision-group wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->