### PR TITLE
:seedling: Deprecate addon InstallNamespace in v1alpha1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ RUNTIME ?= podman
 RUNTIME_IMAGE_NAME ?= openshift-api-generator
 
 verify-gocilint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 	go vet ./...
 	${GOPATH}/bin/golangci-lint run --timeout=3m ./...
 

--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -86,6 +86,7 @@ spec:
               installNamespace:
                 default: open-cluster-management-agent-addon
                 description: |-
+                  Deprecated: Use AddonDeploymentConfig instead.
                   installNamespace is the namespace on the managed cluster to install the addon agent.
                   If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
                 maxLength: 63

--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -34,6 +34,7 @@ type ManagedClusterAddOn struct {
 // ManagedClusterAddOnSpec defines the install configuration of
 // an addon agent on managed cluster.
 type ManagedClusterAddOnSpec struct {
+	// Deprecated: Use AddonDeploymentConfig instead.
 	// installNamespace is the namespace on the managed cluster to install the addon agent.
 	// If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
 	// +optional

--- a/test/integration/api/managedclusteraddon_test.go
+++ b/test/integration/api/managedclusteraddon_test.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("ManagedClusterAddOn API test", func() {
 			metav1.GetOptions{},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo(testNamespace))
+		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo(testNamespace)) //nolint:staticcheck
 	})
 
 	ginkgo.It("Should create a ManagedClusterAddOn with empty spec", func() {
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("ManagedClusterAddOn API test", func() {
 			metav1.GetOptions{},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo("open-cluster-management-agent-addon"))
+		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo("open-cluster-management-agent-addon")) //nolint:staticcheck
 	})
 
 	ginkgo.It("Should update the ManagedClusterAddOn status without config", func() {
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("ManagedClusterAddOn API test", func() {
 			metav1.GetOptions{},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo(testNamespace))
+		gomega.Expect(mca.Spec.InstallNamespace).To(gomega.BeEquivalentTo(testNamespace)) //nolint:staticcheck
 
 		mca.Status.ConfigReferences = []addonv1alpha1.ConfigReference{
 			{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Marked InstallNamespace as deprecated and updated descriptions to recommend using AddonDeploymentConfig.

* Chores
  * Updated linting tool to golangci-lint v2.4.0 for development consistency.

* Tests
  * Added lint suppression directives to silence static analysis warnings without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->