### PR TITLE
:bug: fix: ManifestWorkReplicaSet applied capitalization error

### DIFF
--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -741,7 +741,7 @@ spec:
                       description: Summary totals of resulting ManifestWorks for the
                         placement
                       properties:
-                        Applied:
+                        applied:
                           description: 'Applied is the number of ManifestWorks with
                             condition Applied: true'
                           type: integer
@@ -763,7 +763,7 @@ spec:
               summary:
                 description: Summary totals of resulting ManifestWorks for all placements
                 properties:
-                  Applied:
+                  applied:
                     description: 'Applied is the number of ManifestWorks with condition
                       Applied: true'
                     type: integer

--- a/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/work/v1alpha1/types_manifestworkreplicaset.go
@@ -132,7 +132,7 @@ type ManifestWorkReplicaSetSummary struct {
 	// TODO: Degraded is the number of ManifestWorks with condition Degraded: true
 	Degraded int `json:"degraded"`
 	// Applied is the number of ManifestWorks with condition Applied: true
-	Applied int `json:"Applied"`
+	Applied int `json:"applied"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Summary

fix: ManifestWorkReplicaSet applied capitalization error

## Related issue(s)

Found this weird capitalization while working on https://github.com/open-cluster-management-io/ocm/issues/1054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed status summary field from Applied to applied across the ManifestWorkReplicaSet API, including top-level summary and placementSummary sections, aligning JSON/YAML output.

* **Bug Fixes**
  * Updated CRD schema to validate the new summary.applied field consistently.

* **Impact**
  * Clients referencing status.summary.Applied must switch to status.summary.applied (including placementSummary). Update manifests, scripts, and dashboards to reflect the new field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->