### PR TITLE
🐛 Allow empty string for AgentInstallNamespace to support template namespaces

### DIFF
--- a/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
+++ b/addon/v1alpha1/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
@@ -41,10 +41,12 @@ spec:
             properties:
               agentInstallNamespace:
                 default: open-cluster-management-agent-addon
-                description: AgentInstallNamespace is the namespace where the add-on
-                  agent should be installed on the managed cluster.
+                description: |-
+                  AgentInstallNamespace is the namespace where the add-on agent should be installed on the managed cluster.
+                  For template-type addons: set to empty string "" to use the namespace defined in the addonTemplate.
+                  For non-template addons: defaults to "open-cluster-management-agent-addon" if not specified.
                 maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                 type: string
               customizedVariables:
                 description: |-

--- a/addon/v1alpha1/types_addondeploymentconfig.go
+++ b/addon/v1alpha1/types_addondeploymentconfig.go
@@ -54,10 +54,12 @@ type AddOnDeploymentConfigSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 
 	// AgentInstallNamespace is the namespace where the add-on agent should be installed on the managed cluster.
+	// For template-type addons: set to empty string "" to use the namespace defined in the addonTemplate.
+	// For non-template addons: defaults to "open-cluster-management-agent-addon" if not specified.
 	// +optional
 	// +kubebuilder:default=open-cluster-management-agent-addon
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
 	AgentInstallNamespace string `json:"agentInstallNamespace,omitempty"`
 
 	// ResourceRequirements specify the resources required by add-on agents.

--- a/test/integration/api/addondeploymentconfig_test.go
+++ b/test/integration/api/addondeploymentconfig_test.go
@@ -159,4 +159,99 @@ var _ = ginkgo.Describe("AddOnDeploymentConfig API test", func() {
 		)
 		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
 	})
+
+	ginkgo.It("Should create a AddOnDeploymentConfig with empty agentInstallNamespace", func() {
+		addOnDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      addOnDeploymentConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: "",
+			},
+		}
+
+		_, err := hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(testNamespace).Create(
+			context.TODO(),
+			addOnDeploymentConfig,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should create a AddOnDeploymentConfig with valid agentInstallNamespace", func() {
+		addOnDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      addOnDeploymentConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: "my-custom-namespace",
+			},
+		}
+
+		_, err := hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(testNamespace).Create(
+			context.TODO(),
+			addOnDeploymentConfig,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should not create a AddOnDeploymentConfig with invalid agentInstallNamespace (starts with hyphen)", func() {
+		addOnDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      addOnDeploymentConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: "-invalid",
+			},
+		}
+
+		_, err := hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(testNamespace).Create(
+			context.TODO(),
+			addOnDeploymentConfig,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should not create a AddOnDeploymentConfig with invalid agentInstallNamespace (contains uppercase)", func() {
+		addOnDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      addOnDeploymentConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: "Invalid-Namespace",
+			},
+		}
+
+		_, err := hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(testNamespace).Create(
+			context.TODO(),
+			addOnDeploymentConfig,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should not create a AddOnDeploymentConfig with agentInstallNamespace exceeding max length", func() {
+		addOnDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      addOnDeploymentConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: rand.String(64), // max is 63
+			},
+		}
+
+		_, err := hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(testNamespace).Create(
+			context.TODO(),
+			addOnDeploymentConfig,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
+	})
 })


### PR DESCRIPTION
## Summary

This PR implements the API repository changes for [ocm#1209](https://github.com/open-cluster-management-io/ocm/issues/1209), allowing template-type addons to use the namespace defined in their `addonTemplate` by setting `agentInstallNamespace` to an empty string.

## Changes

### 1. API Type Changes
- Updated `AgentInstallNamespace` validation pattern in `types_addondeploymentconfig.go` from `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` to `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` to allow empty strings
- Added documentation clarifying the behavior difference between template-type and non-template addons

### 2. CRD Updates
- Regenerated CRD manifests with the updated validation pattern and documentation

### 3. Integration Tests
- Added comprehensive test coverage for `AgentInstallNamespace` validation:
  - Valid: empty string (for template namespaces)
  - Valid: custom namespace name
  - Invalid: starts with hyphen
  - Invalid: contains uppercase
  - Invalid: exceeds max length (63 chars)

## Behavior

**For template-type addons:**
- Set `agentInstallNamespace: ""` to use the namespace defined in the `addonTemplate`
- Set to a specific value to override the template namespace

**For non-template addons:**
- Defaults to `"open-cluster-management-agent-addon"` if not specified
- Maintains existing behavior

## Backward Compatibility

✅ Fully backward compatible - existing configs continue to work with the default namespace

## Related issue(s)

open-cluster-management-io/ocm#1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent install namespace is now optional. Leaving it empty will use the add-on template’s namespace for template-based add-ons, or default to the standard agent add-on namespace for non-template add-ons.

* **Documentation**
  * Expanded description clarifying behavior and defaults for the agent install namespace across template and non-template add-ons.

* **Tests**
  * Added integration tests covering empty, valid, and invalid agent install namespace scenarios, including length and character constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->