### PR TITLE
:sparkles:  Add MWRS status fields

### DIFF
--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -751,11 +751,19 @@ spec:
                           type: integer
                         degraded:
                           type: integer
+                        desiredTotal:
+                          description: DesiredTotal is the number of ManifestWorks
+                            that will be created by the ManifestWorkReplicaSet.
+                          type: integer
                         progressing:
                           type: integer
                         total:
                           description: Total number of ManifestWorks managed by the
                             ManifestWorkReplicaSet
+                          type: integer
+                        updated:
+                          description: Updated is the number of clusters with updated
+                            revision applied.
                           type: integer
                       type: object
                   type: object
@@ -773,10 +781,18 @@ spec:
                     type: integer
                   degraded:
                     type: integer
+                  desiredTotal:
+                    description: DesiredTotal is the number of ManifestWorks that
+                      will be created by the ManifestWorkReplicaSet.
+                    type: integer
                   progressing:
                     type: integer
                   total:
                     description: Total number of ManifestWorks managed by the ManifestWorkReplicaSet
+                    type: integer
+                  updated:
+                    description: Updated is the number of clusters with updated revision
+                      applied.
                     type: integer
                 type: object
             type: object

--- a/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/work/v1alpha1/types_manifestworkreplicaset.go
@@ -133,6 +133,10 @@ type ManifestWorkReplicaSetSummary struct {
 	Degraded int `json:"degraded"`
 	// Applied is the number of ManifestWorks with condition Applied: true
 	Applied int `json:"applied"`
+	// DesiredTotal is the number of ManifestWorks that will be created by the ManifestWorkReplicaSet.
+	DesiredTotal int `json:"desiredTotal"`
+	// Updated is the number of clusters with updated revision applied.
+	Updated int `json:"updated"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR is to make CRD changes to MWRS regarding status updates. The two changes made are:
1. PlacementRolledOut to represent workload is stable on all the cluster selected by the placement. 
2. Add desiredTotal to the summary to show the list of clusters the placement selected. 

## Related issue(s)
https://github.com/open-cluster-management-io/ocm/issues/1235#issuecomment-3519250097
https://github.com/open-cluster-management-io/enhancements/blob/main/enhancements/sig-architecture/229-manifestworkreplicaset-rollback/README.md

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desired-total metric to manifest work replica set status summaries to show how many manifest works will be created.
  * Added an updated-count metric to indicate how many clusters have the updated revision applied, alongside existing progress, availability, degradation, and applied metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->