### PR TITLE
🌱  Upgrade Go version to 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
 defaults:
   run:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@ FROM fedora:34
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:/go/bin:$PATH
 
-ARG GO_VERSION=1.24.0
+ARG GO_VERSION=1.25.0
 RUN curl -LO https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/api
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11


### PR DESCRIPTION
## Summary
This PR upgrades the Go version from 1.24 to 1.25 across the project:
- Updated `go.mod` directive to `1.25.0`
- Updated GitHub Actions workflow to use Go `1.25`
- Updated Dockerfile.build to use Go `1.25.0`

## Verification
- ✅ All verification checks passed (`make verify`)
- ✅ Build successful (`make build`)
- ✅ All unit tests passed (`make test`)

## Test Plan
- [x] Run `make verify` to ensure code generation and linting pass
- [x] Run `make build` to ensure project builds successfully
- [x] Run `make test` to ensure all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.24 to 1.25 across build configurations and CI/CD pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->