### PR TITLE
🐛 Update Kubernetes list type markers for conditions

### DIFF
--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -524,6 +524,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     configReferences:
                       description: configReferences is a list of current add-on configuration
                         references.

--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -192,6 +192,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configReferences:
                 description: |-
                   configReferences is a list of current add-on configuration references.

--- a/addon/v1alpha1/types_clustermanagementaddon.go
+++ b/addon/v1alpha1/types_clustermanagementaddon.go
@@ -211,8 +211,8 @@ type InstallProgression struct {
 	ConfigReferences []InstallConfigReference `json:"configReferences,omitempty"`
 
 	// conditions describe the state of the managed and monitored components for the operator.
-	// +patchMergeKey=type
-	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 }

--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -101,8 +101,8 @@ type Subject struct {
 // +k8s:deepcopy-gen=true
 type ManagedClusterAddOnStatus struct {
 	// conditions describe the state of the managed and monitored components for the operator.
-	// +patchMergeKey=type
-	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 

--- a/addon/v1beta1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1beta1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -524,6 +524,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     configReferences:
                       description: configReferences is a list of current add-on configuration
                         references.
@@ -1098,6 +1101,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     configReferences:
                       description: configReferences is a list of current add-on configuration
                         references.

--- a/addon/v1beta1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1beta1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -192,6 +192,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configReferences:
                 description: |-
                   configReferences is a list of current add-on configuration references.
@@ -545,6 +548,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configReferences:
                 description: |-
                   configReferences is a list of current add-on configuration references.

--- a/addon/v1beta1/types_clustermanagementaddon.go
+++ b/addon/v1beta1/types_clustermanagementaddon.go
@@ -172,8 +172,8 @@ type InstallProgression struct {
 	ConfigReferences []InstallConfigReference `json:"configReferences,omitempty"`
 
 	// conditions describe the state of the managed and monitored components for the operator.
-	// +patchMergeKey=type
-	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 }

--- a/addon/v1beta1/types_managedclusteraddon.go
+++ b/addon/v1beta1/types_managedclusteraddon.go
@@ -133,8 +133,8 @@ type Subject struct {
 // +k8s:deepcopy-gen=true
 type ManagedClusterAddOnStatus struct {
 	// conditions describe the state of the managed and monitored components for the operator.
-	// +patchMergeKey=type
-	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 

--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -262,6 +262,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               managedNamespaces:
                 description: |-
                   managedNamespaces are a list of namespaces managed by the clustersets the
@@ -330,6 +333,9 @@ spec:
                         - type
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     name:
                       description: name is the name of the namespace.
                       maxLength: 63

--- a/cluster/v1/types.go
+++ b/cluster/v1/types.go
@@ -145,6 +145,8 @@ const (
 // ManagedClusterStatus represents the current status of joined managed cluster.
 type ManagedClusterStatus struct {
 	// conditions contains the different condition statuses for this managed cluster.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions"`
 
 	// capacity represents the total resource capacity from all nodeStatuses
@@ -214,6 +216,8 @@ type ClusterSetManagedNamespaceConfig struct {
 	ClusterSet string `json:"clusterSet"`
 
 	// conditions are the status conditions of the managed namespace
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/cluster/v1alpha1/types_addonplacementscore.go
+++ b/cluster/v1alpha1/types_addonplacementscore.go
@@ -24,8 +24,6 @@ type AddOnPlacementScore struct {
 // AddOnPlacementScoreStatus represents the current status of AddOnPlacementScore.
 type AddOnPlacementScoreStatus struct {
 	// Conditions contain the different condition statuses for this AddOnPlacementScore.
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional

--- a/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
@@ -601,6 +601,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               decisionGroups:
                 description: List of decision groups determined by the placement and
                   DecisionStrategy.

--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -438,6 +438,8 @@ type PlacementStatus struct {
 	DecisionGroups []DecisionGroupStatus `json:"decisionGroups"`
 
 	// Conditions contains the different condition status for this Placement.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions"`
 }

--- a/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -591,6 +591,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               generations:
                 description: Generations are used to determine when an item needs
                   to be reconciled or has changed in a way that needs a reaction.

--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -850,6 +850,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               generations:
                 description: Generations are used to determine when an item needs
                   to be reconciled or has changed in a way that needs a reaction.

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -499,6 +499,8 @@ type ClusterManagerStatus struct {
 	// Progressing: Components in hub are in a transitioning state.
 	// Degraded: Components in hub do not match the desired configuration and only provide
 	// degraded service.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions"`
 
 	// Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.

--- a/operator/v1/types_klusterlet.go
+++ b/operator/v1/types_klusterlet.go
@@ -358,6 +358,8 @@ type KlusterletStatus struct {
 	// Progressing: Components in the managed cluster are in a transitioning state.
 	// Degraded: Components in the managed cluster do not match the desired configuration and only provide
 	// degraded service.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions"`
 
 	// Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.

--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -453,6 +453,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               resourceStatus:
                 description: |-
                   ResourceStatus represents the status of each resource in manifestwork deployed on a
@@ -532,6 +535,9 @@ spec:
                             - type
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - type
+                          x-kubernetes-list-type: map
                         resourceMeta:
                           description: ResourceMeta represents the group, version,
                             kind, name and namespace of a resoure.

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -470,6 +470,8 @@ type ManifestWorkStatus struct {
 	// 3. Available represents workload in ManifestWork exists on the managed cluster.
 	// 4. Degraded represents the current state of workload does not match the desired
 	// state for a certain period.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ResourceStatus represents the status of each resource in manifestwork deployed on a
@@ -538,6 +540,8 @@ type ManifestCondition struct {
 
 	// Conditions represents the conditions of this resource on a managed cluster.
 	// +required
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions"`
 }
 

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -723,6 +723,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               placementSummary:
                 description: PlacementRef Summary
                 items:

--- a/work/v1alpha1/types_manifestworkreplicaset.go
+++ b/work/v1alpha1/types_manifestworkreplicaset.go
@@ -79,6 +79,8 @@ type ManifestWorkReplicaSetStatus struct {
 	// Valid condition types are:
 	// 1. AppliedManifestWorks represents ManifestWorks have been distributed as per placement All, Partial, None, Problem
 	// 2. PlacementRefValid
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Summary totals of resulting ManifestWorks for all placements


### PR DESCRIPTION
Replace deprecated +patchMergeKey and +patchStrategy markers with +listType=map and +listMapKey=type for condition arrays across all API versions. This ensures proper strategic merge patch behavior and aligns with current Kubernetes API conventions.

Updates CRD YAML files with corresponding x-kubernetes-list-type and x-kubernetes-list-map-keys annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API schemas across addon, cluster, operator, and work resource types to improve list field merging and validation behavior. These infrastructure-level changes enhance system reliability and consistency without affecting user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->