### PR TITLE
:sparkles: add ClusterManagementAddOn ManagedClusterAddOn conversions

### DIFF
--- a/addon/v1alpha1/addondeploymentconfig_conversion.go
+++ b/addon/v1alpha1/addondeploymentconfig_conversion.go
@@ -1,0 +1,6 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package v1alpha1
+
+// Hub marks AddOnDeploymentConfig as the conversion hub version
+func (r *AddOnDeploymentConfig) Hub() {}

--- a/addon/v1alpha1/clustermanagementaddon_conversion.go
+++ b/addon/v1alpha1/clustermanagementaddon_conversion.go
@@ -1,0 +1,6 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package v1alpha1
+
+// Hub marks ClusterManagementAddOn as the conversion hub version
+func (r *ClusterManagementAddOn) Hub() {}

--- a/addon/v1alpha1/managedclusteraddon_conversion.go
+++ b/addon/v1alpha1/managedclusteraddon_conversion.go
@@ -1,0 +1,6 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package v1alpha1
+
+// Hub marks ManagedClusterAddOn as the conversion hub version
+func (r *ManagedClusterAddOn) Hub() {}

--- a/addon/v1beta1/addondeploymentconfig_conversion.go
+++ b/addon/v1beta1/addondeploymentconfig_conversion.go
@@ -1,0 +1,46 @@
+// Copyright Contributors to the Open Cluster Management project
+package v1beta1
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	"open-cluster-management.io/api/addon/v1alpha1"
+)
+
+// ConvertTo converts the receiver (v1beta1) into v1alpha1.
+func (src *AddOnDeploymentConfig) ConvertTo(dstRaw conversion.Hub) error {
+	dst, ok := dstRaw.(*v1alpha1.AddOnDeploymentConfig)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.AddOnDeploymentConfig, got %T", dstRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec - since the types are identical between versions, we can use the generated conversion
+	if err := Convert_v1beta1_AddOnDeploymentConfigSpec_To_v1alpha1_AddOnDeploymentConfigSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	return nil
+}
+
+// ConvertFrom converts from v1alpha1 into the receiver (v1beta1).
+func (dst *AddOnDeploymentConfig) ConvertFrom(srcRaw conversion.Hub) error {
+	src, ok := srcRaw.(*v1alpha1.AddOnDeploymentConfig)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.AddOnDeploymentConfig, got %T", srcRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec - since the types are identical between versions, we can use the generated conversion
+	if err := Convert_v1alpha1_AddOnDeploymentConfigSpec_To_v1beta1_AddOnDeploymentConfigSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	return nil
+}

--- a/addon/v1beta1/clustermanagementaddon_conversion.go
+++ b/addon/v1beta1/clustermanagementaddon_conversion.go
@@ -1,0 +1,56 @@
+// Copyright Contributors to the Open Cluster Management project
+package v1beta1
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	"open-cluster-management.io/api/addon/v1alpha1"
+)
+
+// ConvertTo converts the receiver (v1beta1) into v1alpha1.
+func (src *ClusterManagementAddOn) ConvertTo(dstRaw conversion.Hub) error {
+	dst, ok := dstRaw.(*v1alpha1.ClusterManagementAddOn)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.ClusterManagementAddOn, got %T", dstRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec
+	if err := Convert_v1beta1_ClusterManagementAddOnSpec_To_v1alpha1_ClusterManagementAddOnSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	// Convert Status
+	if err := Convert_v1beta1_ClusterManagementAddOnStatus_To_v1alpha1_ClusterManagementAddOnStatus(&src.Status, &dst.Status, nil); err != nil {
+		return fmt.Errorf("failed to convert status: %w", err)
+	}
+
+	return nil
+}
+
+// ConvertFrom converts from v1alpha1 into the receiver (v1beta1).
+func (dst *ClusterManagementAddOn) ConvertFrom(srcRaw conversion.Hub) error {
+	src, ok := srcRaw.(*v1alpha1.ClusterManagementAddOn)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.ClusterManagementAddOn, got %T", srcRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec
+	if err := Convert_v1alpha1_ClusterManagementAddOnSpec_To_v1beta1_ClusterManagementAddOnSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	// Convert Status
+	if err := Convert_v1alpha1_ClusterManagementAddOnStatus_To_v1beta1_ClusterManagementAddOnStatus(&src.Status, &dst.Status, nil); err != nil {
+		return fmt.Errorf("failed to convert status: %w", err)
+	}
+
+	return nil
+}

--- a/addon/v1beta1/conversion.go
+++ b/addon/v1beta1/conversion.go
@@ -3,6 +3,7 @@ package v1beta1
 
 import (
 	"fmt"
+
 	certificates "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"open-cluster-management.io/api/addon/v1alpha1"

--- a/addon/v1beta1/managedclusteraddon_conversion.go
+++ b/addon/v1beta1/managedclusteraddon_conversion.go
@@ -1,0 +1,86 @@
+// Copyright Contributors to the Open Cluster Management project
+package v1beta1
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	"open-cluster-management.io/api/addon/v1alpha1"
+)
+
+const (
+	// InstallNamespaceAnnotation is the annotation key for storing installNamespace
+	// This is used because installNamespace field was removed in v1beta1
+	InstallNamespaceAnnotation = "addon.open-cluster-management.io/v1alpha1-install-namespace"
+)
+
+// ConvertTo converts the receiver (v1beta1) into v1alpha1.
+func (src *ManagedClusterAddOn) ConvertTo(dstRaw conversion.Hub) error {
+	dst, ok := dstRaw.(*v1alpha1.ManagedClusterAddOn)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.ManagedClusterAddOn, got %T", dstRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec
+	if err := Convert_v1beta1_ManagedClusterAddOnSpec_To_v1alpha1_ManagedClusterAddOnSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	// Restore installNamespace from annotation
+	// This field was removed in v1beta1, so we store it in annotation
+	if installNs, ok := src.Annotations[InstallNamespaceAnnotation]; ok {
+		dst.Spec.InstallNamespace = installNs
+	}
+
+	// Convert Status
+	if err := Convert_v1beta1_ManagedClusterAddOnStatus_To_v1alpha1_ManagedClusterAddOnStatus(&src.Status, &dst.Status, nil); err != nil {
+		return fmt.Errorf("failed to convert status: %w", err)
+	}
+
+	// Manually populate deprecated ConfigReferent field in ConfigReferences
+	// The native conversion doesn't handle this deprecated field from v1alpha1.ConfigReference
+	// We need to copy from DesiredConfig.ConfigReferent if DesiredConfig exists
+	for i := range dst.Status.ConfigReferences {
+		if dst.Status.ConfigReferences[i].DesiredConfig != nil {
+			dst.Status.ConfigReferences[i].ConfigReferent = dst.Status.ConfigReferences[i].DesiredConfig.ConfigReferent
+		}
+	}
+
+	return nil
+}
+
+// ConvertFrom converts from v1alpha1 into the receiver (v1beta1).
+func (dst *ManagedClusterAddOn) ConvertFrom(srcRaw conversion.Hub) error {
+	src, ok := srcRaw.(*v1alpha1.ManagedClusterAddOn)
+	if !ok {
+		return fmt.Errorf("expected *v1alpha1.ManagedClusterAddOn, got %T", srcRaw)
+	}
+
+	// Copy the ObjectMeta
+	dst.ObjectMeta = src.ObjectMeta
+
+	// Convert Spec
+	if err := Convert_v1alpha1_ManagedClusterAddOnSpec_To_v1beta1_ManagedClusterAddOnSpec(&src.Spec, &dst.Spec, nil); err != nil {
+		return fmt.Errorf("failed to convert spec: %w", err)
+	}
+
+	// Save installNamespace to annotation (removed in v1beta1)
+	// This field exists in v1alpha1 but not in v1beta1, so we preserve it in annotations
+	if src.Spec.InstallNamespace != "" {
+		if dst.Annotations == nil {
+			dst.Annotations = make(map[string]string)
+		}
+		dst.Annotations[InstallNamespaceAnnotation] = src.Spec.InstallNamespace
+	}
+
+	// Convert Status
+	if err := Convert_v1alpha1_ManagedClusterAddOnStatus_To_v1beta1_ManagedClusterAddOnStatus(&src.Status, &dst.Status, nil); err != nil {
+		return fmt.Errorf("failed to convert status: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:


This pull request introduces conversion logic between `v1alpha1` and `v1beta1` API versions for both `ClusterManagementAddOn` and `ManagedClusterAddOn` resources in the Open Cluster Management project. The main focus is to enable seamless conversion between these versions, handling fields that have been added, removed, or deprecated, and ensuring backward compatibility.

**Conversion logic implementation:**

* [`addon/v1beta1/clustermanagementaddon_conversion.go`](diffhunk://#diff-615ab950a1959b65bc19b7eaef562757df6ec2b8f0f6a9749b85b792dbd1d880R1-R56): Implements `ConvertTo` and `ConvertFrom` methods for `ClusterManagementAddOn`, enabling conversion between `v1alpha1` and `v1beta1` versions. These methods handle metadata, spec, and status fields.
* [`addon/v1beta1/managedclusteraddon_conversion.go`](diffhunk://#diff-717ba1345ea13b597fdfc1761d4a8b0cbb961009797bad4a5ffd9183e2a6d056R1-R86): Implements `ConvertTo` and `ConvertFrom` methods for `ManagedClusterAddOn`, including special handling for the `installNamespace` field (removed in `v1beta1` and preserved via annotation) and the deprecated `ConfigReferent` field in `ConfigReferences`.

**Conversion hub markers:**

* [`addon/v1alpha1/clustermanagementaddon_conversion.go`](diffhunk://#diff-f52a640ad770fbda5a7f1189dbfb559ffd7ba3e61d8ae033843a2f550d0b1922R1-R6): Adds a `Hub()` method to `ClusterManagementAddOn` to mark it as the conversion hub version.
* [`addon/v1alpha1/managedclusteraddon_conversion.go`](diffhunk://#diff-fea01c79785d5669718e83b714db7966298e7fe50aee54a53eb9bac64b88a46dR1-R6): Adds a `Hub()` method to `ManagedClusterAddOn` to mark it as the conversion hub version.

**Miscellaneous:**

* [`addon/v1beta1/conversion.go`](diffhunk://#diff-3d6391c68bda0eafb09503e2e2971458b287258fa83be88e65d3506cddae7c6fR6): Minor import formatting update. ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This pull request introduces conversion logic between `v1alpha1` and `v1beta1` API versions for both `ClusterManagementAddOn` and `ManagedClusterAddOn` resources.
The main focus is to enable seamless conversion between these versions, handling fields that have been added, removed, or deprecated, and ensuring backward compatibility.

**Conversion logic implementation:**

* [`addon/v1beta1/clustermanagementaddon_conversion.go`](diffhunk://#diff-615ab950a1959b65bc19b7eaef562757df6ec2b8f0f6a9749b85b792dbd1d880R1-R56): Implements `ConvertTo` and `ConvertFrom` methods for `ClusterManagementAddOn`, enabling conversion between `v1alpha1` and `v1beta1` versions. These methods handle metadata, spec, and status fields.
* [`addon/v1beta1/managedclusteraddon_conversion.go`](diffhunk://#diff-717ba1345ea13b597fdfc1761d4a8b0cbb961009797bad4a5ffd9183e2a6d056R1-R86): Implements `ConvertTo` and `ConvertFrom` methods for `ManagedClusterAddOn`, including special handling for the `installNamespace` field (removed in `v1beta1` and preserved via annotation) and the deprecated `ConfigReferent` field in `ConfigReferences`.

**Conversion hub markers:**

* [`addon/v1alpha1/clustermanagementaddon_conversion.go`](diffhunk://#diff-f52a640ad770fbda5a7f1189dbfb559ffd7ba3e61d8ae033843a2f550d0b1922R1-R6): Adds a `Hub()` method to `ClusterManagementAddOn` to mark it as the conversion hub version.
* [`addon/v1alpha1/managedclusteraddon_conversion.go`](diffhunk://#diff-fea01c79785d5669718e83b714db7966298e7fe50aee54a53eb9bac64b88a46dR1-R6): Adds a `Hub()` method to `ManagedClusterAddOn` to mark it as the conversion hub version.

**Miscellaneous:**

* [`addon/v1beta1/conversion.go`](diffhunk://#diff-3d6391c68bda0eafb09503e2e2971458b287258fa83be88e65d3506cddae7c6fR6): Minor import formatting update.

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-version API conversion across v1alpha1/v1beta1 to enable seamless upgrades and downgrades.
  * Preserves deprecated fields and install-location data during version transitions to maintain backward compatibility.
  * Ensures robust error reporting during conversions for safer runtime migrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->