### PR TITLE
🌱 Addon webhook configuration

### DIFF
--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -95,6 +95,45 @@ spec:
                     description: Default includes optional configurations for clustermanager
                       in the Default mode.
                     properties:
+                      addonWebhookConfiguration:
+                        description: AddonWebhookConfiguration represents the customized
+                          webhook-server configuration of addons.
+                        properties:
+                          bindConfiguration:
+                            description: BindConfiguration represents server bind
+                              configuration for the webhook server
+                            properties:
+                              healthProbePort:
+                                default: 8000
+                                description: |-
+                                  HealthProbePort represents the bind port of a webhook-server's healthcheck endpoint. The default value is 8000.
+                                  Healthchecks may be disabled by setting a value less than or equal to 0.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                              hostNetwork:
+                                description: |-
+                                  HostNetwork enables running webhook pods in host networking mode.
+                                  This may be required in some installations, such as EKS with Calico CNI,
+                                  to allow the API Server to communicate with the webhook pods.
+                                type: boolean
+                              metricsPort:
+                                default: 8080
+                                description: |-
+                                  MetricsPort represents the bind port for a webhook-server's metric endpoint. The default value is 8080.
+                                  Metrics may be disabled by setting a value less than or equal to 0.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                              port:
+                                default: 9443
+                                description: Port represents the primary bind port
+                                  of a server. The default value is 9443.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                            type: object
+                        type: object
                       registrationWebhookConfiguration:
                         description: RegistrationWebhookConfiguration represents the
                           customized webhook-server configuration of registration.
@@ -178,6 +217,61 @@ spec:
                     description: Hosted includes configurations we need for clustermanager
                       in the Hosted mode.
                     properties:
+                      addonWebhookConfiguration:
+                        description: AddonWebhookConfiguration represents the customized
+                          webhook-server configuration of addons.
+                        properties:
+                          address:
+                            description: |-
+                              Address represents the address of a webhook-server.
+                              It could be in IP format or fqdn format.
+                              The Address must be reachable by apiserver of the hub cluster.
+                            pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
+                            type: string
+                          bindConfiguration:
+                            description: BindConfiguration represents server bind
+                              configuration for the webhook server
+                            properties:
+                              healthProbePort:
+                                default: 8000
+                                description: |-
+                                  HealthProbePort represents the bind port of a webhook-server's healthcheck endpoint. The default value is 8000.
+                                  Healthchecks may be disabled by setting a value less than or equal to 0.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                              hostNetwork:
+                                description: |-
+                                  HostNetwork enables running webhook pods in host networking mode.
+                                  This may be required in some installations, such as EKS with Calico CNI,
+                                  to allow the API Server to communicate with the webhook pods.
+                                type: boolean
+                              metricsPort:
+                                default: 8080
+                                description: |-
+                                  MetricsPort represents the bind port for a webhook-server's metric endpoint. The default value is 8080.
+                                  Metrics may be disabled by setting a value less than or equal to 0.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                              port:
+                                default: 9443
+                                description: Port represents the primary bind port
+                                  of a server. The default value is 9443.
+                                format: int32
+                                maximum: 65535
+                                type: integer
+                            type: object
+                          port:
+                            default: 443
+                            description: Port represents the external port of a webhook-server.
+                              The default value of Port is 443.
+                            format: int32
+                            maximum: 65535
+                            type: integer
+                        required:
+                        - address
+                        type: object
                       registrationWebhookConfiguration:
                         description: RegistrationWebhookConfiguration represents the
                           customized webhook-server configuration of registration.

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -387,6 +387,10 @@ type DefaultClusterManagerConfiguration struct {
 	// WorkWebhookConfiguration represents the customized webhook-server configuration of work.
 	// +optional
 	WorkWebhookConfiguration DefaultWebhookConfiguration `json:"workWebhookConfiguration,omitempty"`
+
+	// AddonWebhookConfiguration represents the customized webhook-server configuration of addons.
+	// +optional
+	AddonWebhookConfiguration DefaultWebhookConfiguration `json:"addonWebhookConfiguration,omitempty"`
 }
 
 // HostedClusterManagerConfiguration represents customized configurations we need to set for clustermanager in the Hosted mode.
@@ -398,6 +402,10 @@ type HostedClusterManagerConfiguration struct {
 	// WorkWebhookConfiguration represents the customized webhook-server configuration of work.
 	// +optional
 	WorkWebhookConfiguration HostedWebhookConfiguration `json:"workWebhookConfiguration,omitempty"`
+
+	// AddonWebhookConfiguration represents the customized webhook-server configuration of addons.
+	// +optional
+	AddonWebhookConfiguration HostedWebhookConfiguration `json:"addonWebhookConfiguration,omitempty"`
 }
 
 // BindConfiguration represents customization of server bindings

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -343,6 +343,7 @@ func (in *DefaultClusterManagerConfiguration) DeepCopyInto(out *DefaultClusterMa
 	*out = *in
 	in.RegistrationWebhookConfiguration.DeepCopyInto(&out.RegistrationWebhookConfiguration)
 	in.WorkWebhookConfiguration.DeepCopyInto(&out.WorkWebhookConfiguration)
+	in.AddonWebhookConfiguration.DeepCopyInto(&out.AddonWebhookConfiguration)
 	return
 }
 
@@ -492,6 +493,7 @@ func (in *HostedClusterManagerConfiguration) DeepCopyInto(out *HostedClusterMana
 	*out = *in
 	in.RegistrationWebhookConfiguration.DeepCopyInto(&out.RegistrationWebhookConfiguration)
 	in.WorkWebhookConfiguration.DeepCopyInto(&out.WorkWebhookConfiguration)
+	in.AddonWebhookConfiguration.DeepCopyInto(&out.AddonWebhookConfiguration)
 	return
 }
 

--- a/test/integration/api/clustermanager_test.go
+++ b/test/integration/api/clustermanager_test.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/onsi/ginkgo"
@@ -86,6 +87,9 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "test:test",
 				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "test:test",
+				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(HaveOccurred())
@@ -100,6 +104,9 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				},
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "192.168.2.4",
+				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "192.168.2.5",
 				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
@@ -116,6 +123,9 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
 				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "addon.foo.com",
+				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -130,6 +140,9 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				},
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
+				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "addon.foo.com",
 				},
 			}
 			clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
@@ -149,6 +162,9 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
 				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "addon.foo.com",
+				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(HaveOccurred())
@@ -165,6 +181,10 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo2.com",
 					Port:    2443,
+				},
+				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
+					Address: "foo3.com",
+					Port:    3443,
 				},
 			}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Adding support for configuration of the addon webhook.


## Related issue(s)

https://github.com/open-cluster-management-io/ocm/pull/1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added addon webhook configuration options for standard and hosted deployment modes, allowing customization of health probe port, metrics port, host network flag, bind port, and (hosted only) webhook address and external port with sensible defaults and validation.
* **Tests**
  * Extended hosted-mode tests to cover addon webhook configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->