### PR TITLE
🐛 Replace kubebuilder-release-tools action with local script

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -6,18 +6,19 @@ on:
   # This means changes won't kick in to this file until merged onto the
   # main branch.
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   verify:
-    name: verify PR contents
-    permissions:
-      checks: write
-      pull-requests: read
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-      - name: Verifier action
-        id: verifier
-        uses: kubernetes-sigs/kubebuilder-release-tools@v0.3.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+
+      - name: Check if PR title is valid
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          ./hack/verify-pr-title.sh "${PR_TITLE}"

--- a/hack/verify-pr-title.sh
+++ b/hack/verify-pr-title.sh
@@ -1,0 +1,57 @@
+# Copyright Contributors to the Open Cluster Management project
+#!/bin/bash
+
+# Original Copyright:
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define regex patterns
+WIP_REGEX="^\W?WIP\W"
+TAG_REGEX="^\[[[:alnum:]\._-]*\]"
+PR_TITLE="$1"
+
+# Trim WIP and tags from title
+trimmed_title=$(echo "$PR_TITLE" | sed -E "s/$WIP_REGEX//" | sed -E "s/$TAG_REGEX//" | xargs -0)
+
+# Normalize common emojis in text form to actual emojis
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:sparkles:/✨/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:bug:/🐛/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:book:/📖/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:memo:/📝/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:warning:/⚠️/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:seedling:/🌱/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:question:/❓/g")
+
+# Check PR type prefix
+if [[ "$trimmed_title" =~ ^(⚠|✨|🐛|📖|🚀|🌱) ]]; then
+    echo "PR title is valid: $trimmed_title"
+else
+    echo "Error: No matching PR type indicator found in title."
+    echo "Please copy the appropriate `:text:` or icon to the beginning of your PR title:"
+    echo ":sparkles: ✨ feature"
+    echo ":bug: 🐛 bug fix"
+    echo ":book: 📖 docs"
+    echo ":memo: 📝 proposal"
+    echo ":warning: ⚠️ breaking change"
+    echo ":seedling: 🌱 other/misc"
+    echo ":question: ❓ requires manual review/categorization"
+    exit 1
+fi
+
+# Check that PR title does not contain Issue or PR number
+if [[ "$trimmed_title" =~ \#[0-9]+ ]]; then
+    echo "Error: PR title should not contain issue or PR number."
+    echo "Issue numbers belong in the PR body as either \"Fixes #XYZ\" (if it closes the issue or PR), or something like \"Related to #XYZ\" (if it's just related)."
+    exit 1
+fi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Kubebuilder-release-tools images are no longer available gcr.io https://docs.cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

Swapping to a local action script copied from https://github.com/kubernetes-sigs/cluster-api/pull/11062 and edited to match OCM's PR emoji set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PR verification workflow to enforce standardized title formatting with required type prefixes (⚠, ✨, 🐛, 📖, 🚀, 🌱) and format validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->