### PR TITLE
🌱 Remove unsupported addon webhook hosted mode config

### DIFF
--- a/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/operator/v1/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -217,61 +217,6 @@ spec:
                     description: Hosted includes configurations we need for clustermanager
                       in the Hosted mode.
                     properties:
-                      addonWebhookConfiguration:
-                        description: AddonWebhookConfiguration represents the customized
-                          webhook-server configuration of addons.
-                        properties:
-                          address:
-                            description: |-
-                              Address represents the address of a webhook-server.
-                              It could be in IP format or fqdn format.
-                              The Address must be reachable by apiserver of the hub cluster.
-                            pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
-                            type: string
-                          bindConfiguration:
-                            description: BindConfiguration represents server bind
-                              configuration for the webhook server
-                            properties:
-                              healthProbePort:
-                                default: 8000
-                                description: |-
-                                  HealthProbePort represents the bind port of a webhook-server's healthcheck endpoint. The default value is 8000.
-                                  Healthchecks may be disabled by setting a value less than or equal to 0.
-                                format: int32
-                                maximum: 65535
-                                type: integer
-                              hostNetwork:
-                                description: |-
-                                  HostNetwork enables running webhook pods in host networking mode.
-                                  This may be required in some installations, such as EKS with Calico CNI,
-                                  to allow the API Server to communicate with the webhook pods.
-                                type: boolean
-                              metricsPort:
-                                default: 8080
-                                description: |-
-                                  MetricsPort represents the bind port for a webhook-server's metric endpoint. The default value is 8080.
-                                  Metrics may be disabled by setting a value less than or equal to 0.
-                                format: int32
-                                maximum: 65535
-                                type: integer
-                              port:
-                                default: 9443
-                                description: Port represents the primary bind port
-                                  of a server. The default value is 9443.
-                                format: int32
-                                maximum: 65535
-                                type: integer
-                            type: object
-                          port:
-                            default: 443
-                            description: Port represents the external port of a webhook-server.
-                              The default value of Port is 443.
-                            format: int32
-                            maximum: 65535
-                            type: integer
-                        required:
-                        - address
-                        type: object
                       registrationWebhookConfiguration:
                         description: RegistrationWebhookConfiguration represents the
                           customized webhook-server configuration of registration.

--- a/operator/v1/types_clustermanager.go
+++ b/operator/v1/types_clustermanager.go
@@ -402,10 +402,6 @@ type HostedClusterManagerConfiguration struct {
 	// WorkWebhookConfiguration represents the customized webhook-server configuration of work.
 	// +optional
 	WorkWebhookConfiguration HostedWebhookConfiguration `json:"workWebhookConfiguration,omitempty"`
-
-	// AddonWebhookConfiguration represents the customized webhook-server configuration of addons.
-	// +optional
-	AddonWebhookConfiguration HostedWebhookConfiguration `json:"addonWebhookConfiguration,omitempty"`
 }
 
 // BindConfiguration represents customization of server bindings

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -493,7 +493,6 @@ func (in *HostedClusterManagerConfiguration) DeepCopyInto(out *HostedClusterMana
 	*out = *in
 	in.RegistrationWebhookConfiguration.DeepCopyInto(&out.RegistrationWebhookConfiguration)
 	in.WorkWebhookConfiguration.DeepCopyInto(&out.WorkWebhookConfiguration)
-	in.AddonWebhookConfiguration.DeepCopyInto(&out.AddonWebhookConfiguration)
 	return
 }
 

--- a/test/integration/api/clustermanager_test.go
+++ b/test/integration/api/clustermanager_test.go
@@ -87,9 +87,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "test:test",
 				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "test:test",
-				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(HaveOccurred())
@@ -104,9 +101,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				},
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "192.168.2.4",
-				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "192.168.2.5",
 				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
@@ -123,9 +117,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
 				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "addon.foo.com",
-				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -140,9 +131,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				},
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
-				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "addon.foo.com",
 				},
 			}
 			clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
@@ -162,9 +150,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo.com",
 				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "addon.foo.com",
-				},
 			}
 			_, err := operatorClient.OperatorV1().ClusterManagers().Create(context.TODO(), clusterManager, metav1.CreateOptions{})
 			Expect(err).To(HaveOccurred())
@@ -181,10 +166,6 @@ var _ = Describe("Create Cluster Manager Hosted mode", func() {
 				WorkWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
 					Address: "foo2.com",
 					Port:    2443,
-				},
-				AddonWebhookConfiguration: operatorv1.HostedWebhookConfiguration{
-					Address: "foo3.com",
-					Port:    3443,
 				},
 			}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Hosted mode is not supported for addon webhook

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/pull/1420#discussion_r2944104057
https://github.com/open-cluster-management-io/ocm/issues/1442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed addon webhook configuration from Hosted mode ClusterManager. The addonWebhookConfiguration option and its associated settings (address, port configuration, health probes, and network parameters) are no longer available. This simplification reduces the configuration surface for Hosted deployments while other webhook options remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->