### PR TITLE
:seedling: Add +k8s:openapi-gen=true tag to cluster/v1

### DIFF
--- a/cluster/v1/doc.go
+++ b/cluster/v1/doc.go
@@ -2,6 +2,7 @@
 // Package v1 contains API Schema definitions for the cluster v1 API group
 
 // +k8s:deepcopy-gen=package,register
+// +k8s:openapi-gen=true
 // +kubebuilder:validation:Optional
 // +groupName=cluster.open-cluster-management.io
 package v1


### PR DESCRIPTION
## Summary

Add the `+k8s:openapi-gen=true` build tag to `cluster/v1/doc.go`, making it consistent with `cluster/v1beta2/doc.go` which already has this tag.

## Motivation

Starting with **Kubernetes 1.35** (`k8s.io/code-generator` v0.35.x), the `openapi-gen` tool became stricter about which packages it processes. Previously, packages passed via `--extra-pkgs` would always be included in OpenAPI schema generation. In v0.35.x, the tool now **requires** the `+k8s:openapi-gen=true` tag in a package's `doc.go` — without it, the package is silently skipped even when explicitly listed.

This is a **breaking change for downstream consumers** that build aggregated API servers serving `ManagedCluster` resources. When they upgrade to k8s 0.35 and run `openapi-gen`, the `cluster/v1` types (e.g., `ManagedCluster`, `ManagedClusterList`, `ManagedClusterSpec`) are no longer included in the generated OpenAPI definitions. At runtime, the aggregated API server crashes at startup with:

```
unable to get openapi models: cannot find model definition for
open-cluster-management.io/api/cluster/v1.ManagedCluster.
If you added a new type, you may need to add +k8s:openapi-gen=true
to the package or type and run code-gen again
```

## Why this affects downstream but not this repo

This repo (`open-cluster-management-io/api`) only runs `gen_client` and `gen_deepcopy` — it does **not** run `gen_openapi`, so the missing tag has no impact here.

However, downstream consumers that build **aggregated API servers** (using `k8s.io/apiserver`) need to generate OpenAPI schema definitions for all types they serve. They use `kube::codegen::gen_openapi` with `--extra-pkgs "open-cluster-management.io/api/cluster/v1"` to include `ManagedCluster` types. With k8s 0.35's stricter `openapi-gen`, these consumers are blocked unless this tag is present.

## Impact

- **No impact on this repo** — the tag is inert when `openapi-gen` is not run
- **Unblocks all downstream aggregated API servers** upgrading to k8s 0.35+
- **Consistent** with `cluster/v1beta2/doc.go` which already has this tag

## Changes

- `cluster/v1/doc.go`: Added `// +k8s:openapi-gen=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled OpenAPI specification generation for the API group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->