### PR TITLE
:bug: fix: omit PlacementDecision score field when zero-valued

### DIFF
--- a/cluster/v1beta1/types_placementdecision.go
+++ b/cluster/v1beta1/types_placementdecision.go
@@ -61,7 +61,7 @@ type ClusterDecision struct {
 
 	// Score is the computed score for the cluster based on configured prioritizers
 	// +optional
-	Score int64 `json:"score"`
+	Score int64 `json:"score,omitzero"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
## Summary

Add omitzero json tag to ClusterDecision.Score so that the default zero value is not serialized to JSON. The field remains int64 (non-pointer) and is only included when explicitly set to a non-zero value.

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized JSON serialization to omit zero score values in cluster decision responses, reducing payload size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->