### PR TITLE
:sparkles: feat: add "random" placement prioritizer

### DIFF
--- a/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
@@ -388,6 +388,7 @@ spec:
                                 2) Steady: ensure the existing decision is stabilized.
                                 3) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.
                                 4) Spread: spread the workload evenly to topologies.
+                                5) Random: select clusters randomly.
                               type: string
                             type:
                               default: BuiltIn

--- a/cluster/v1beta1/types_placement.go
+++ b/cluster/v1beta1/types_placement.go
@@ -298,6 +298,7 @@ type ScoreCoordinate struct {
 	// 2) Steady: ensure the existing decision is stabilized.
 	// 3) ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.
 	// 4) Spread: spread the workload evenly to topologies.
+	// 5) Random: select clusters randomly.
 	// +optional
 	BuiltIn string `json:"builtIn,omitempty"`
 


### PR DESCRIPTION
## Summary

Add "random" placement prioritizer to Placement API description.

## Related issue(s)

- https://github.com/open-cluster-management-io/ocm/issues/1507
- https://github.com/open-cluster-management-io/ocm/pull/1506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Random prioritizer option for cluster placement. Users can now randomly select clusters when deploying workloads, providing an alternative distribution strategy for flexible resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->