### PR TITLE
✨ feature: migrate structural validation to kubebuilder CEL markers (Phase 1)

### DIFF
--- a/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -424,6 +424,9 @@ spec:
                           x-kubernetes-embedded-resource: true
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
+                        x-kubernetes-validations:
+                        - message: manifests should not be empty
+                          rule: size(self) > 0
                     type: object
                 type: object
               registration:

--- a/addon/v1beta1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/addon/v1beta1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -424,6 +424,9 @@ spec:
                           x-kubernetes-embedded-resource: true
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
+                        x-kubernetes-validations:
+                        - message: manifests should not be empty
+                          rule: size(self) > 0
                     type: object
                 type: object
               registration:
@@ -1020,6 +1023,9 @@ spec:
                           x-kubernetes-embedded-resource: true
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
+                        x-kubernetes-validations:
+                        - message: manifests should not be empty
+                          rule: size(self) > 0
                     type: object
                 type: object
               registration:

--- a/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -107,10 +107,16 @@ spec:
                     url:
                       description: URL is the URL of apiserver endpoint of the managed
                         cluster.
+                      maxLength: 2048
                       type: string
+                      x-kubernetes-validations:
+                      - message: url must be a valid https URL
+                        rule: isURL(self) && url(self).getScheme() == 'https' && url(self).getHost()
+                          != ''
                   required:
                   - url
                   type: object
+                maxItems: 32
                 type: array
               taints:
                 description: |-
@@ -360,6 +366,11 @@ spec:
                 type: object
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name format is not correct
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+        - message: metadata.name must be no more than 63 characters
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/cluster/v1/types.go
+++ b/cluster/v1/types.go
@@ -31,6 +31,8 @@ import (
 //
 // After the hub cluster creates the cluster namespace, the klusterlet agent on the ManagedCluster pushes
 // the credential to the hub cluster to use against the kube-apiserver of the ManagedCluster.
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')",message="metadata.name format is not correct"
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="metadata.name must be no more than 63 characters"
 type ManagedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -49,6 +51,7 @@ type ManagedClusterSpec struct {
 	// ManagedClusterClientConfigs represents a list of the apiserver address of the managed cluster.
 	// If it is empty, the managed cluster has no accessible address for the hub to connect with it.
 	// +optional
+	// +kubebuilder:validation:MaxItems=32
 	ManagedClusterClientConfigs []ClientConfig `json:"managedClusterClientConfigs,omitempty"`
 
 	// hubAcceptsClient represents that hub accepts the joining of Klusterlet agent on
@@ -81,6 +84,8 @@ type ManagedClusterSpec struct {
 type ClientConfig struct {
 	// URL is the URL of apiserver endpoint of the managed cluster.
 	// +required
+	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:XValidation:rule="isURL(self) && url(self).getScheme() == 'https' && url(self).getHost() != ''",message="url must be a valid https URL"
 	URL string `json:"url"`
 
 	// CABundle is the ca bundle to connect to apiserver of the managed cluster.

--- a/cluster/v1beta2/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/cluster/v1beta2/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -117,6 +117,10 @@ spec:
                 type: array
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: The ManagedClusterSetBinding must have the same name as the target
+            ManagedClusterSet
+          rule: self.metadata.name == self.spec.clusterSet
     served: true
     storage: true
     subresources:

--- a/cluster/v1beta2/types_managedclustersetbinding.go
+++ b/cluster/v1beta2/types_managedclustersetbinding.go
@@ -16,6 +16,7 @@ import (
 // ManagedClusterSet if both have a RBAC rules to CREATE on the virtual subresource of managedclustersets/bind.
 // Workloads that you create in the same namespace can only be distributed to ManagedClusters
 // in ManagedClusterSets that are bound in this namespace by higher-level controllers.
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == self.spec.clusterSet",message="The ManagedClusterSetBinding must have the same name as the target ManagedClusterSet"
 type ManagedClusterSetBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -104,6 +104,10 @@ const (
 	// When enabled, a debug-server container will be added to the placement pod, providing
 	// /debug/placements/* endpoints for placement scheduling simulation and debugging.
 	PlacementDebugServer featuregate.Feature = "PlacementDebugServer"
+
+	// CELValidation replaces the legacy Go Validating Webhooks with native Kubernetes
+	// CEL validation rules and ValidatingAdmissionPolicy bindings.
+	CELValidation featuregate.Feature = "CELValidation"
 )
 
 // DefaultSpokeRegistrationFeatureGates consists of all known ocm-registration
@@ -127,6 +131,7 @@ var DefaultHubRegistrationFeatureGates = map[featuregate.Feature]featuregate.Fea
 	ResourceCleanup:            {Default: true, PreRelease: featuregate.Beta},
 	ClusterProfile:             {Default: false, PreRelease: featuregate.Alpha},
 	ClusterImporter:            {Default: false, PreRelease: featuregate.Alpha},
+	CELValidation:              {Default: false, PreRelease: featuregate.Alpha},
 }
 
 var DefaultHubAddonManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -147,6 +152,7 @@ var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 	ManifestWorkReplicaSet:       {Default: false, PreRelease: featuregate.Alpha},
 	CloudEventsDrivers:           {Default: false, PreRelease: featuregate.Alpha},
 	CleanUpCompletedManifestWork: {Default: false, PreRelease: featuregate.Alpha},
+	CELValidation:                {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultSpokeWorkFeatureGates consists of all known ocm work feature keys for work agent.

--- a/test/integration/api/managedcluster_test.go
+++ b/test/integration/api/managedcluster_test.go
@@ -148,6 +148,25 @@ var _ = ginkgo.Describe("ManagedCluster v1 Enhanced API test", func() {
 			gomega.Expect(createdCluster.Spec.ManagedClusterClientConfigs[0].URL).Should(gomega.Equal("https://example.com:6443"))
 		})
 
+		ginkgo.It("should reject HTTPS URL without host", func() {
+			managedCluster := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: clusterv1.ManagedClusterSpec{
+					HubAcceptsClient: true,
+					ManagedClusterClientConfigs: []clusterv1.ClientConfig{
+						{
+							URL: "https://",
+						},
+					},
+				},
+			}
+
+			_, err := hubClusterClient.ClusterV1().ManagedClusters().Create(context.TODO(), managedCluster, metav1.CreateOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("should accept valid HTTPS URL", func() {
 			managedCluster := &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -407,6 +407,9 @@ spec:
                       x-kubernetes-embedded-resource: true
                       x-kubernetes-preserve-unknown-fields: true
                     type: array
+                    x-kubernetes-validations:
+                    - message: manifests should not be empty
+                      rule: size(self) > 0
                 type: object
             type: object
           status:

--- a/work/v1/types.go
+++ b/work/v1/types.go
@@ -67,6 +67,7 @@ type Manifest struct {
 type ManifestsTemplate struct {
 	// manifests represents a list of kubernetes resources to be deployed on a managed cluster.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="manifests should not be empty"
 	Manifests []Manifest `json:"manifests,omitempty"`
 }
 

--- a/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -443,6 +443,9 @@ spec:
                           x-kubernetes-embedded-resource: true
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
+                        x-kubernetes-validations:
+                        - message: manifests should not be empty
+                          rule: size(self) > 0
                     type: object
                 type: object
               placementRefs:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR implements **Phase 1** of the CEL Validation Migration as outlined and approved in [Enhancement Proposal #181](https://github.com/open-cluster-management-io/enhancements/pull/181). 

It replaces legacy Go-based structural webhook validation with native Kubernetes `+kubebuilder:validation:XValidation` CEL markers directly on the Custom Resource structs.

**Validations Migrated:**
- `ManagedCluster`: Enforced HTTPS format for `Spec.ManagedClusterClientConfigs` URLs and regex format for `metadata.name`.
- `ManagedClusterSetBinding`: Enforced cross-field parity (`metadata.name == spec.clusterSet`).
- `ManifestWork`: Enforced `manifests` array is not empty.

*Note: The corresponding `ValidatingAdmissionPolicy` additions and FeatureGate operator updates (Phase 2) will be submitted in a follow-up PR to the `ocm` repository once this API change is merged.*

## Related issue(s)

Fixes phase 1 of https://github.com/open-cluster-management-io/ocm/issues/1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Alpha `CELValidation` feature gate for native Kubernetes API validation.

* **Bug Fixes**
  * Enforced non-empty manifests for add-on templates, manifest works, and manifest replica sets.
  * Strengthened `ManagedCluster` validation for names, client configuration limits, and secure HTTPS URLs.
  * Ensured `ManagedClusterSetBinding` names match the specified cluster set.

* **Tests**
  * Added integration coverage for valid and invalid `ManagedCluster` names, client URLs, and configuration limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->