### PR TITLE
✨ feat: add ManifestWorkApplyLatency spoke-work feature gate

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -77,12 +77,12 @@ const (
 	// is not a scalar value.
 	RawFeedbackJsonString featuregate.Feature = "RawFeedbackJsonString"
 
-	// ManifestWorkApplyLatency makes the work agent emit structured spoke-apply log lines
-	// (mw_spoke_apply at reconcile start, mw_resource_spoke_apply per applied resource, and
-	// mw_spoke_apply_result at reconcile end) for measuring hub->spoke propagation latency. The lines
-	// carry the manifestwork name/namespace/generation, the applied resource identity, an apply
-	// timestamp, and the manifestwork labels. Read-only applies are a noop and do not emit.
-	ManifestWorkApplyLatency featuregate.Feature = "ManifestWorkApplyLatency"
+	// ManifestWorkApplyLogs makes the work agent in the spoke cluster emit structured logs on the apply of the manifestwork and its resources
+	// Log lines are written with three types of logs - mw_spoke_apply at reconcile start, mw_resource_spoke_apply per applied resource, and
+	// mw_spoke_apply_result at reconcile.
+	// The lines carry the manifestwork name/namespace/generation, the applied resource identity, an apply
+	// timestamp, and the manifestwork labels. Read-only applies emit an observation log instead.
+	ManifestWorkApplyLogs featuregate.Feature = "ManifestWorkApplyLogs"
 
 	// ResourceCleanup will start gc controller to clean up resources in cluster ns after cluster is deleted.
 	ResourceCleanup featuregate.Feature = "ResourceCleanup"
@@ -161,5 +161,5 @@ var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 var DefaultSpokeWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ExecutorValidatingCaches: {Default: false, PreRelease: featuregate.Alpha},
 	RawFeedbackJsonString:    {Default: false, PreRelease: featuregate.Alpha},
-	ManifestWorkApplyLatency: {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkApplyLogs:    {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -77,6 +77,13 @@ const (
 	// is not a scalar value.
 	RawFeedbackJsonString featuregate.Feature = "RawFeedbackJsonString"
 
+	// ManifestWorkApplyLatency makes the work agent emit structured spoke-apply log lines
+	// (mw_spoke_apply at reconcile start, mw_resource_spoke_apply per applied resource, and
+	// mw_spoke_apply_result at reconcile end) for measuring hub->spoke propagation latency. The lines
+	// carry the manifestwork name/namespace/generation, the applied resource identity, an apply
+	// timestamp, and the manifestwork labels. Read-only applies are a noop and do not emit.
+	ManifestWorkApplyLatency featuregate.Feature = "ManifestWorkApplyLatency"
+
 	// ResourceCleanup will start gc controller to clean up resources in cluster ns after cluster is deleted.
 	ResourceCleanup featuregate.Feature = "ResourceCleanup"
 
@@ -154,4 +161,5 @@ var DefaultHubWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 var DefaultSpokeWorkFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ExecutorValidatingCaches: {Default: false, PreRelease: featuregate.Alpha},
 	RawFeedbackJsonString:    {Default: false, PreRelease: featuregate.Alpha},
+	ManifestWorkApplyLatency: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add the ManifestWorkApplyLatency alpha feature gate (default off) to DefaultSpokeWorkFeatureGates. When enabled, the work agent emits structured apply-latency log lines for measuring hub->spoke ManifestWork propagation latency. Read-only applies emit an observation line, not an apply.

## Related issue(s) 
https://github.com/open-cluster-management-io/ocm/issues/1633

Fixes # 1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed the alpha feature gate to clarify its support for ManifestWork apply observation logs.
  * When enabled, read-only applies emit an observation log.
  * The feature remains disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->